### PR TITLE
cmd/site: opportunistic onion support

### DIFF
--- a/cmd/site/altonions.go
+++ b/cmd/site/altonions.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+var altOnionServer = os.Getenv("ALT_ONION_SERVER")
+
+func altOnionHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if altOnionServer != "" {
+			w.Header().Set("Alt-Svc", fmt.Sprintf(`h2="%s:443"; ma=86400; persist=1`, altOnionServer))
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/site/main.go
+++ b/cmd/site/main.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	ln.Log(context.Background(), ln.F{"action": "http_listening", "port": port})
-	http.ListenAndServe(":"+port, s)
+	http.ListenAndServe(":"+port, altOnionHandler(s))
 }
 
 func requestIDMiddleware(next http.Handler) http.Handler {

--- a/cmd/site/main.go
+++ b/cmd/site/main.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	ln.Log(context.Background(), ln.F{"action": "http_listening", "port": port})
-	http.ListenAndServe(":"+port, altOnionHandler(s))
+	ln.FatalErr(context.Background(), http.ListenAndServe(":"+port, altOnionHandler(s)))
 }
 
 func requestIDMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
Sets up [opportunistic onions a-la cloudflare](https://blog.cloudflare.com/cloudflare-onion-service/). For christine.website, the config is:

```
ALT_ONION_SERVER=4ksso2xq7xcmh5imm4plm4eq5sphfnpz6jz3l2jlvxaheguywbs6e2ad.onion
```

This will allow tor users over the clearnet to automatically upgrade to christine.website over a v3 onion.

## TODO

- [x] basic functionality
- [ ] blogpost