### PR TITLE
Update signalboost.dhall, adding DDR as a job-seeker.

### DIFF
--- a/signalboost.dhall
+++ b/signalboost.dhall
@@ -50,6 +50,27 @@ in  [ Person::{
       , twitter = "https://twitter.com/euforic"
       }
     , Person::{
+      , name = "David Roberts"
+      , tags =
+        [ "ux"
+        , "ui"
+        , "documentation"
+        , "web"
+        , "html5"
+        , "javascript"
+        , "python"
+        , "qt"
+        , "bash"
+        , "front-end"
+        , "full-stack"
+        , "linux"
+        , "embedded"
+        , "sql"
+        ]
+      , gitLink = "https://github.com/ddr0"
+      , twitter = "https://twitter.com/DDR_4"
+      }
+    , Person::{
       , name = "Jamie Bliss"
       , tags = [ "python", "devops", "full-stack", "saltstack", "web", "linux" ]
       , gitLink = "https://github.com/astronouth7303"


### PR DESCRIPTION
Thanks for doing this, Xe. I know it's not much, but it means a lot to me.