### PR TITLE
delete <center> tags on images

### DIFF
--- a/blog/ios-development-pro-tip-for-private-ca-2019-03-22.markdown
+++ b/blog/ios-development-pro-tip-for-private-ca-2019-03-22.markdown
@@ -20,9 +20,7 @@ img {
 }
 </style>
 
-<center>
 ![](/static/img/ios_profiles.png)
-</center>
 
 - Go up a level to General
 - Select About
@@ -30,9 +28,7 @@ img {
 - Each root that has been installed via a profile will be listed below the heading Enable Full Trust For Root Certificates
 - Users can toggle on/off trust for each root:
 
-<center>
 ![](/static/img/ios_cert_trust.png)
-</center>
 
 Please understand that by doing this, users will potentially be vulnerable to a
 [HTTPS man in the middle attack a-la Superfish](https://slate.com/technology/2015/02/lenovo-superfish-scandal-why-its-one-of-the-worst-consumer-computing-screw-ups-ever.html). Please ensure that you have appropriate measures in place to keep the signing key for the CA safe.

--- a/blog/templeos-1-installation-and-basic-use-2019-05-20.markdown
+++ b/blog/templeos-1-installation-and-basic-use-2019-05-20.markdown
@@ -111,33 +111,23 @@ Make sure to remove the TempleOS live CD from your hardware or it will be booted
 
 The [TempleOS Bootloader](https://github.com/Xe/TempleOS/blob/1dd8859b7803355f41d75222d01ed42d5dda057f/Adam/Opt/Boot/BootMHDIns.HC#L69) presents a helpful menu to let you choose if you want to boot from a copy of the old boot record (preserved at install time), drive C or drive D. Press 1:
 
-<center>
 ![TempleOS boot, picking the partition](/static/img/tos/tos_boot_1.png)
-</center>
 
 The first boot requires the dictionary to be uncompressed as well as other housekeeping chores, so let it do its thing:
 
-<center>
 ![TempleOS boot, chores](/static/img/tos/tos_boot_2.png)
-</center>
 
 Once it is done, you will see if the option to take the tour. I highly suggest going through this tour, but that is beyond the scope of this article, so we'll assume you pressed `n`:
 
-<center>
 ![TempleOS boot, denying the tour](/static/img/tos/tos_boot_3.png)
-</center>
 
 ### Using the Compiler
 
-<center>
 ![TempleOS boot, HolyC prompt](/static/img/tos/tos_boot_4.png)
-</center>
 
 The "shell" is itself an interface to the HolyC (similar to C) compiler. There is no difference between a "shell" REPL and a HolyC repl. This is stupidly powerful:
 
-<center>
 ![TempleOS hello world](/static/img/tos/tos_compiler_1.png)
-</center>
 
 ```
 "Hello, world\n";
@@ -147,37 +137,25 @@ Let's make this into a "program" and disassemble it. This is way easier than it 
 
 Open a new file with `Ed("HelloWorld.HC");` (the semicolon is important):
 
-<center>
 ![TempleOS opening a file](/static/img/tos/tos_compiler_2.png)
-</center>
 
-<center>
 ![TempleOS editor screen](/static/img/tos/tos_compiler_3.png)
-</center>
 
 Now press Alt-Shift-a to kill autocomplete:
 
-<center>
 ![TempleOS sans autocomplete](/static/img/tos/tos_compiler_4.png)
-</center>
 
 Click the `X` in the upper right-hand corner to close the other shell window:
 
-<center>
 ![TempleOS sans other window](/static/img/tos/tos_compiler_5.png)
-</center>
 
 Finally press drag the right side of the window to maximize the editor pane:
 
-<center>
 ![TempleOS full screen editor](/static/img/tos/tos_compiler_6.png)
-</center>
 
 Let's put the hello word example into the program and press `F5` to run it:
 
-<center>
 ![TempleOS hello world in a file](/static/img/tos/tos_compiler_7.png)
-</center>
 
 Neat! Close that shell window that just popped up. Let's put this hello world code into a function:
 
@@ -191,9 +169,7 @@ HelloWorld;
 
 Now press `F5` again:
 
-<center>
 ![TempleOS hello world from a function](/static/img/tos/tos_compiler_8.png)
-</center>
 
 Let's disassemble it:
 
@@ -205,9 +181,7 @@ U0 HelloWorld() {
 Uf("HelloWorld");
 ```
 
-<center>
 ![TempleOS hello world disassembled](/static/img/tos/tos_compiler_9.png)
-</center>
 
 The `Uf` function also works with anything else, including things like the editor:
 
@@ -215,15 +189,11 @@ The `Uf` function also works with anything else, including things like the edito
 Uf("Ed");
 ```
 
-<center>
 ![TempleOS editor disassembled](/static/img/tos/tos_compiler_10.png)
-</center>
 
 All of the red underscored things that look like links actually are links to the source code of functions. While the HolyC compiler builds things, it internally keeps a sourcemap (much like webapp sourcemaps or how gcc relates errors at runtime to lines of code for the developer) of all of the functions it compiles. Let's look at the definition of `Free()`:
 
-<center>
 ![TempleOS Free() function](/static/img/tos/tos_compiler_11.png)
-</center>
 
 And from here you can dig deeper into the kernel source code.
 

--- a/blog/wasmcloud-progress-2019-12-08.markdown
+++ b/blog/wasmcloud-progress-2019-12-08.markdown
@@ -139,7 +139,7 @@ h
 I think this is the smallest (if not one of the smallest) quine generator in the
 world. I even got this program running on bare metal:
 
-<center>![](/static/blog/xeos_h.png)</center>
+![](/static/blog/xeos_h.png)
 
 [hlang]: https://h.christine.website
 [vlang]: https://vlang.io


### PR DESCRIPTION
I found more broken images on the following pages:

- https://christine.website/blog/ios-development-pro-tip-for-private-ca-2019-03-22
- https://christine.website/blog/templeos-1-installation-and-basic-use-2019-05-20
- https://christine.website/blog/wasmcloud-progress-2019-12-08

Implemented a fix in the same way as #224 