### PR TITLE
css: constraint iframe max width

### DIFF
--- a/css/hack.css
+++ b/css/hack.css
@@ -43,6 +43,9 @@ pre code {
   text-shadow: none;
   margin: 1.75rem 0;
 }
+iframe {
+  max-width: 100%;
+}
 a {
   cursor: pointer;
   color: #ff2e88;


### PR DESCRIPTION
Last blog post contains a Youtube iframe which is too large on mobile. Constraint its width to maximum viewport width.