### PR TITLE
Fix broken file links

### DIFF
--- a/blog/nixos-desktop-flow-2020-04-25.markdown
+++ b/blog/nixos-desktop-flow-2020-04-25.markdown
@@ -63,7 +63,7 @@ Let's consider a simple example, my [gruvbox-inspired CSS file][gruvboxcss]'s
 [`default.nix`][gcssdefaultnix] file':
 
 [gruvboxcss]: https://github.com/Xe/gruvbox-css
-[gcssdefaultnix]: https://github.com/Xe/gruvbox-css/blob/master/default.nix
+[gcssdefaultnix]: https://github.com/Xe/gruvbox-css/blob/6e1841c94190a1e06e63a2596767e66c35671320/default.nix
 
 ```nix
 { pkgs ? import <nixpkgs> { } }:
@@ -169,7 +169,7 @@ gruvbox.css
 For a more complicated package, let's look at the [build directions of the
 website you are reading right now][sitedefaultnix]:
 
-[sitedefaultnix]: https://github.com/Xe/site/blob/master/site.nix
+[sitedefaultnix]: https://github.com/Xe/site/blob/2559274d95d67ca66cc252276d7a6a0a6bbe47b9/site.nix
 
 ```nix
 { pkgs ? import (import ./nix/sources.nix).nixpkgs }:
@@ -521,7 +521,7 @@ This is a little bit more work in the short term, but as a result I get a setup
 that is easier to recreate on more machines in the future. It took me a half
 hour or so to get the configuration for [zathura][zathura] right, but now I have
 [a zathura
-module](https://github.com/Xe/nixos-configs/tree/master/common/users/cadey/zathura)
+module](https://github.com/Xe/nixos-configs/tree/9ff27215c82733a95c1e95e300e0d2362c7e3eff/common/users/cadey/zathura)
 that lets me get exactly the setup I want every time.
 
 [zathura]: https://pwmt.org/projects/zathura/


### PR DESCRIPTION
Hi Xe,

this post gave me a lot and I want to give you something back by fixing some broken links to your GitHub files.

I chose to pin them to commits that were the latest right before you first published this post, so they are consistent with the snippets inside the post. I also pinned the gruvbox-css `default.nix` even though the link is working because this not only makes sure the contents behind the link will stay persistent with the post in case you choose to change something in there, but also because this enables others to clone the repo, check out the exact commit and try it out on their own.

I intentionally left some links (like those to your fish / spacemacs / etc. configs) unchanged so that they will always point to the latest files because they are just further examples of what you did and are not closely related to the post.

Thanks for the great explanations :heart:

---

**EDIT:**

I stumbled upon the post about your name change so... :grin: 