### PR TITLE
Improve domain matching for nag warning, add more reddit domains

### DIFF
--- a/static/js/hnwarn.js
+++ b/static/js/hnwarn.js
@@ -2,6 +2,12 @@ import { g, x, r, t } from "./xeact.min.js";
 import { div, ahref, br } from "./xeact-html.min.js";
 import { mkConversation } from "./conversation.js";
 
+// list of regexps for potentially problematic referrers to display the nag to
+const FLAGGED_REFERRERS = [
+    /^https?:\/\/((.+)\.)?reddit\.com/i,
+    /^https?:\/\/news\.ycombinator\.com/i,
+];
+
 const addNag = () => {
     let root = g("refererNotice");
     x(root);
@@ -20,19 +26,10 @@ const addNag = () => {
 };
 
 r(() => {
-    switch (document.referrer) {
-    case "https://news.ycombinator.com/":
+    const ref = document.referrer;
+    if (!ref) return;
+
+    if (FLAGGED_REFERRERS.some(r => r.test(ref))) {
         addNag();
-        break;
-    case "https://www.reddit.com/":
-        addNag();
-        break;
-    case "https://old.reddit.com/":
-        addNag();
-        break;
-    case "https://reddit.com/":
-        addNag();
-        break;
     }
 });
-


### PR DESCRIPTION
As mentioned in IRC.

reddit supports any two-letter code in its subdomain, and has a few special subdomains (`np` for No Participation, `new` for new reddit, `old` for old reddit, and `www`, to name a few). I expect the latter to be more often used, but it's worth throwing a blanket case over every reddit subdomain.

I structured my patch with the expectation that you don't want some sort of other behavior for certain referrers, although it's not too hard to add differing behavior for different categories of sites should you choose.