### PR TITLE
fix small content error: nix flakes can access private repos with git+ssh

### DIFF
--- a/blog/nix-flakes-1-2022-02-21.markdown
+++ b/blog/nix-flakes-1-2022-02-21.markdown
@@ -418,7 +418,7 @@ world. To use a private repo, your flake input URL should look something like
 this:
 
 ```
-ssh+git://git@github.com:user/repo
+git+ssh://git@github.com:user/repo
 ```
 
 [I'm pretty sure you could use private git repos outside of flakes, however it


### PR DESCRIPTION
Sadly using ssh+git does not work. I tested this locally.
See also: https://discourse.nixos.org/t/url-format-for-flake-over-git-ssh/7538/2

EDIT: I really enjoyed that post, keep up the great work!