### PR TITLE
Fix the flake URL format

### DIFF
--- a/blog/nix-flakes-1-2022-02-21.markdown
+++ b/blog/nix-flakes-1-2022-02-21.markdown
@@ -422,7 +422,7 @@ world. To use a private repo, your flake input URL should look something like
 this:
 
 ```
-git+ssh://git@github.com:user/repo
+git+ssh://git@github.com/user/repo?ref=main
 ```
 
 [I'm pretty sure you could use private git repos outside of flakes, however it


### PR DESCRIPTION
Good old Nix changing things. I've also noted the branch format, since they hard-coded it to master by default.