### PR TITLE
Typo fixes on the salary transparency pages

### DIFF
--- a/blog/site-update-salary-transparency.markdown
+++ b/blog/site-update-salary-transparency.markdown
@@ -13,7 +13,7 @@ for years, but I feel this should be more prominently displayed on my website.
 
 As someone who has seen pay discrimination work in action first-hand, data is
 one of the ways that we can end this pointless hiding of information that leads
-to people being uninformed and hirt by their lack of knowledge. By laying my
+to people being uninformed and hurt by their lack of knowledge. By laying my
 hand out in the open like this, I hope to ensure that people are better informed
 about how much money they can make, so that they can be paid equally for equal
 work.

--- a/templates/salary_transparency.rs.html
+++ b/templates/salary_transparency.rs.html
@@ -10,7 +10,7 @@
 
 <p>This page lists my salary for every job I've had in tech. I have had this data open to the public <a href="https://xeiaso.net/blog/my-career-in-dates-titles-salaries-2019-03-14">for years</a>, but I feel this should be more prominently displayed on my website. Other people have copied my approach of having a list of every salary they have ever been payed on their websites, and I would like to set the example by making it prominent on my website.</p>
 
-<p>As someone who has seen pay discrimination work in action first-hand, data is one of the ways that we can end this pointless hiding of information that leads to people being uninformed and hirt by their lack of knowledge. By laying my hand out in the open like this, I hope to ensure that people are better informed about how much money they <i>can</i> make, so that they can be paid equally for equal work.</p>
+<p>As someone who has seen pay discrimination work in action first-hand, data is one of the ways that we can end this pointless hiding of information that leads to people being uninformed and hurt by their lack of knowledge. By laying my hand out in the open like this, I hope to ensure that people are better informed about how much money they <i>can</i> make, so that they can be paid equally for equal work.</p>
 
 <h2>Salary Data</h2>
 


### PR DESCRIPTION
`s/hirt/hurt/`, as discussed on IRC.