### PR TITLE
blog: update devShell to devShells for compatibility with recent spec

### DIFF
--- a/blog/nix-flakes-1-2022-02-21.markdown
+++ b/blog/nix-flakes-1-2022-02-21.markdown
@@ -275,13 +275,13 @@ project is using the same tools.
 project folder I do not have any development tools
 available.](conversation://Cadey/enby)
 
-Flakes has the ability to specify this using the `devShell` flake output. You
+Flakes has the ability to specify this using the `devShells` flake output. You
 can add it to your `flake.nix` using this:
 
 ```nix
-# after defaultApp
+# after apps
 
-devShell = forAllSystems (system:
+devShells = forAllSystems (system:
   let pkgs = nixpkgsFor.${system};
   in {
     default = pkgs.mkShell {


### PR DESCRIPTION
Hi,

As per updated in https://github.com/NixOS/nix/pull/6089, `devShell` has been renamed to `devShells`.

https://github.com/NixOS/nix/blob/4248174e7165f48f92416d13b862e3ef8192a34b/src/nix/flake.cc#L516