### PR TITLE
Domain move 2: code/christine.website

### DIFF
--- a/blog/fun-with-redirection-2021-09-22.markdown
+++ b/blog/fun-with-redirection-2021-09-22.markdown
@@ -337,7 +337,7 @@ example you can take a folder, zip it up and then unzip it over on another
 machine using a command like this:
 
 ```
-$ tar cz ./blog | ssh pneuma tar xz -C ~/code/xeiaso.net/blog
+$ tar cz ./blog | ssh pneuma tar xz -C ~/code/christine.website/blog
 ```
 
 This will run `tar` to create a compressed copy of the `./blog` folder and then

--- a/blog/rust-crates-go-stdlib-2020-09-27.markdown
+++ b/blog/rust-crates-go-stdlib-2020-09-27.markdown
@@ -80,7 +80,7 @@ And now let's run it with `RUST_LOG=trace`:
 ```console
 $ env RUST_LOG=trace cargo run --example logger_test
     Finished dev [unoptimized + debuginfo] target(s) in 0.07s
-     Running `/home/cadey/code/xeiaso.net/target/debug/logger_test`
+     Running `/home/cadey/code/christine.website/target/debug/logger_test`
  TRACE logger_test > starting main
  DEBUG logger_test > debug message
  INFO  logger_test > this is some information
@@ -353,7 +353,7 @@ And you can use it like this:
 
 ```console
 $ cargo run --example json
-   Compiling xesite v2.0.1 (/home/cadey/code/xeiaso.net)
+   Compiling xesite v2.0.1 (/home/cadey/code/christine.website)
     Finished dev [unoptimized + debuginfo] target(s) in 0.43s
      Running `target/debug/examples/json`
 comment: Comment {
@@ -433,7 +433,7 @@ And then let's run this:
 
 ```console
 $ cargo run --example http
-   Compiling xesite v2.0.1 (/home/cadey/code/xeiaso.net)
+   Compiling xesite v2.0.1 (/home/cadey/code/christine.website)
     Finished dev [unoptimized + debuginfo] target(s) in 2.20s
      Running `target/debug/examples/http`
 comment: Comment {
@@ -463,9 +463,9 @@ And then when we run it we get an error back:
 
 ```console
 $ cargo run --example http_fail
-   Compiling xesite v2.0.1 (/home/cadey/code/xeiaso.net)
+   Compiling xesite v2.0.1 (/home/cadey/code/christine.website)
     Finished dev [unoptimized + debuginfo] target(s) in 1.84s
-     Running `/home/cadey/code/xeiaso.net/target/debug/examples/http_fail`
+     Running `/home/cadey/code/christine.website/target/debug/examples/http_fail`
 Error: HTTP status client error (404 Not Found) for url (https://xena.greedo.xeserv.us/files/comment2.json)
 ```
 


### PR DESCRIPTION
In your stream reviewing #518, you mentioned that your website is cloned locally to the `code/christine.website` folder. You reverted a few changes to this folder name. This PR reverts the rest of the changes to `code/christine.website`.