### PR TITLE
Fix missing Docker link in "How I Start: Rust"

### DIFF
--- a/blog/how-i-start-rust-2020-03-15.markdown
+++ b/blog/how-i-start-rust-2020-03-15.markdown
@@ -482,6 +482,8 @@ as UTF-8"` message.
 Many deployment systems use [Docker][docker] to describe a program's environment
 and dependencies. Create a `Dockerfile` with the following contents:
 
+[docker]: https://www.docker.com/
+
 ```Dockerfile
 # Use the minimal image
 FROM rustlang/rust:nightly-slim AS build


### PR DESCRIPTION
This PR fixes a missing link in the blog post [How I Start: Rust](https://xeiaso.net/blog/how-i-start-rust-2020-03-15).