### PR TITLE
signalboost: add entry for ~ajhalili2006

### DIFF
--- a/dhall/signalboost.dhall
+++ b/dhall/signalboost.dhall
@@ -235,14 +235,12 @@ in  [ Person::{
       , gitLink = Some "https://github.com/henri"
       , twitter = Some "https://twitter.com/henri_shustak"
       }
-    , Person:: {
+    , Person::{
       , name = "Andrei Jiroh Halili"
-      , tags =
-      [ "backend", "bash", "nodejs", "deno", "alpinelinux", "linux"
-      ]
-    , gitLink = Some "https://github.com/ajhalili2006"
-    , twitter = Some "https://twitter.com/Kuys_Potpot"
-    , fediverse = Some "https://tilde.zone/@ajhalili2006"
-    , website = Some "https://ajhalili2006.bio.link" --- ~ajhalili2006's page for all of his socials
-    }
+      , tags = [ "backend", "bash", "nodejs", "deno", "alpinelinux", "linux" ]
+      , gitLink = Some "https://github.com/ajhalili2006"
+      , twitter = Some "https://twitter.com/Kuys_Potpot"
+      , fediverse = Some "https://tilde.zone/@ajhalili2006"
+      , website = Some "https://ajhalili2006.bio.link"
+      }
     ]

--- a/dhall/signalboost.dhall
+++ b/dhall/signalboost.dhall
@@ -235,4 +235,14 @@ in  [ Person::{
       , gitLink = Some "https://github.com/henri"
       , twitter = Some "https://twitter.com/henri_shustak"
       }
+    , Person:: {
+      , name = "Andrei Jiroh Halili"
+      , tags =
+      [ "backend", "bash", "nodejs", "deno", "alpinelinux", "linux"
+      ]
+    , gitLink = Some "https://github.com/ajhalili2006"
+    , twitter = Some "https://twitter.com/Kuys_Potpot"
+    , fediverse = Some "https://tilde.zone/@ajhalili2006"
+    , website = Some "https://ajhalili2006.bio.link" --- ~ajhalili2006's page for all of his socials
+    }
     ]

--- a/dhall/types/Person.dhall
+++ b/dhall/types/Person.dhall
@@ -3,7 +3,11 @@
     , tags : List Text
     , gitLink : Optional Text
     , twitter : Optional Text
+    , linkedin : Optional Text
+    , fediverse : Optional Text
+    , cover_letter : Optional Text
+    , website: Optional Text
     }
 , default =
-  { name = "", tags = [] : List Text, gitLink = None Text, twitter = None Text }
+  { name = "", tags = [] : List Text, gitLink = None Text, twitter = None Text, linkedin : None Text, fediverse: None Text, cover_letter : None Text, website: None Text }
 }

--- a/dhall/types/Person.dhall
+++ b/dhall/types/Person.dhall
@@ -5,9 +5,17 @@
     , twitter : Optional Text
     , linkedin : Optional Text
     , fediverse : Optional Text
-    , cover_letter : Optional Text
-    , website: Optional Text
+    , coverLetter : Optional Text
+    , website : Optional Text
     }
 , default =
-  { name = "", tags = [] : List Text, gitLink = None Text, twitter = None Text, linkedin : None Text, fediverse: None Text, cover_letter : None Text, website: None Text }
+  { name = ""
+  , tags = [] : List Text
+  , gitLink = None Text
+  , twitter = None Text
+  , linkedin = None Text
+  , fediverse = None Text
+  , coverLetter = None Text
+  , website = None Text
+  }
 }

--- a/src/signalboost.rs
+++ b/src/signalboost.rs
@@ -4,11 +4,14 @@ use serde::Deserialize;
 pub struct Person {
     pub name: String,
     pub tags: Vec<String>,
-
     #[serde(rename = "gitLink")]
     pub git_link: Option<String>,
-
     pub twitter: Option<String>,
+    pub linkedin: Option<String>,
+    pub fediverse: Option<String>,
+    #[serde(rename = "coverLetter")]
+    pub cover_letter: Option<String>,
+    pub website: Option<String>,
 }
 
 #[cfg(test)]

--- a/templates/signalboost.rs.html
+++ b/templates/signalboost.rs.html
@@ -27,6 +27,18 @@
             @if person.twitter.is_some() {
               <a href="@person.twitter.unwrap()">Twitter</a>
             }
+            @if person.linkedin.is_some() {
+              <a href="#person.linkedin.unwrap()">LinkedIn</a>
+            }
+            @if person.fediverse.is_some() {
+              <a href="@person.fediverse.unwrap()">Fediverse</a>
+            }
+            @if person.cover_letter.is_some() {
+              <a href="@person.cover_letter.unwrap()">Cover letter</a>
+            }
+            @if person.website.is_some() {
+              <a href="@person.website.unwrap()">Website</a>
+            }
         </div>
     }
 </div>


### PR DESCRIPTION

Also in this commit:
* Add linkedin and cover_letter (per https://github.com/Xe/site/pull/550#discussion_r1019824691) anmong other things,
  including adding fediverse and website fields
* Update the signalboost.rs HTML template to reflect
  these changes to Person.dhall types