### PR TITLE
Update lorri repo link in how-i-start-nix-2020-03-08.markdown

### DIFF
--- a/blog/how-i-start-nix-2020-03-08.markdown
+++ b/blog/how-i-start-nix-2020-03-08.markdown
@@ -44,7 +44,7 @@ Try 'nix-env --help' for more information.
 Let's install a few other tools to help us with development. First, let's
 install [lorri][lorri] to help us manage our development shell:
 
-[lorri]: https://github.com/target/lorri
+[lorri]: https://github.com/nix-community/lorri
 
 ```
 $ nix-env --install --file https://github.com/target/lorri/archive/master.tar.gz


### PR DESCRIPTION
Was reading your article (great btw) and saw that the lorri tool moved to new repo so here's a small PR with updated URL to lorri