### PR TITLE
Fix text size inflation in some mobile contexts

### DIFF
--- a/static/css/hack.css
+++ b/static/css/hack.css
@@ -1,5 +1,7 @@
 html {
   font-size: 14px;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
 }
 * {
   box-sizing: border-box;


### PR DESCRIPTION
In some situations, mobile devices (in this case, Safari on iOS when in landscape orientation) applies a text inflation algorithm to the page's content. This is to ensure readability of text, in cases where the device has resorted to rendering the desktop layout, shrunk it down, and now needs to blow up the text to compensate. 

The heuristics it uses to determine this are... weird, and can make for some strange jumps in text size, even between elements that are otherwise styled the same. 

![Screenshot of part of a blog post, where different conversation snippets have different text sizing applied to them.](https://user-images.githubusercontent.com/1253214/213895089-bc3489e6-086d-419b-b86a-7a8023ba9abb.png)

(This also affects various other elements around the site, and as the text inflation heuristics are applied on a page-by-page basis, this sometimes means parts of the header and footer can sometimes be different sizes on different pages. Wild.) 

Given the site has a whole "one size fits all" approach to text styling, this seems pretty undesirable. Adding [`text-size-adjust: none`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust) to the root element turns off text inflation and makes everything be the font-size actually defined in CSS.

![Screenshot of the same blog post, but things are all the same size now.](https://user-images.githubusercontent.com/1253214/213895194-25edb8e9-eefa-4c53-9f5a-69dd85fd5995.png)

Hope this helps. Feel free to ask any questions y'all may have. 