### PR TITLE
dhall/jobHistory: Fix endDate of "Archmage of Infrastructure"

### DIFF
--- a/dhall/jobHistory.dhall
+++ b/dhall/jobHistory.dhall
@@ -82,7 +82,7 @@ in  [ Job::{
       , company = tailscale
       , title = "Archmage of Infrastructure"
       , startDate = "2022-03-01"
-      , endDate = Some "2022-04-06"
+      , endDate = Some "2023-04-06"
       , daysWorked = Some 401
       , leaveReason = Some "raise"
       , salary = annualCAD 147150


### PR DESCRIPTION
Hi there,

while reading your salary transparency data, I noticed that the start and end dates of the Archmage of Infrastructure position don't add up. My first guess was that the year was probably a typo, and a quick calculation confirmed that suspicion.

```
$ startDate=$(date --date="2022-03-01" +"%s")
$ endDate=$(date --date="2023-04-06" +"%s")
$ echo "$(((endDate - startDate) / (60 * 60 * 24)))"
401
```

I'm not sure if this is the correct way to fix the date, so please let me know if there are other files that need to be updated as well.

Best regards
Matthias