### PR TITLE
Add missing `waifud` article to the `waifud` series

### DIFF
--- a/blog/waifud-progress-2022-02-06.markdown
+++ b/blog/waifud-progress-2022-02-06.markdown
@@ -1,6 +1,7 @@
 ---
 title: "waifud Progress Report #1"
 date: 2022-02-06
+series: waifud
 tags:
  - waifud
  - zfs


### PR DESCRIPTION
Currently, the `waifud` series only covers the introductory plans post, as well as the second progress report.

This PR adds the first progress report to that series as well. I'm not sure if this is the only place to update this tag though