### PR TITLE
fix blogpost sharing button from non-chromium browsers

### DIFF
--- a/lume/src/_includes/blog.njk
+++ b/lume/src/_includes/blog.njk
@@ -46,7 +46,7 @@ layout: base.njk
             if (navigator.share && navigator.canShare(shareData)) {
                 // console.log("(via navigator.share)");
                 navigator
-                    .share({title: document.title, url: window.location.href})
+                    .share(shareData)
                     .then(() => {
                         console.log("Thanks for sharing!");
                     })

--- a/lume/src/_includes/blog.njk
+++ b/lume/src/_includes/blog.njk
@@ -43,16 +43,26 @@ layout: base.njk
                 title: document.title,
                 url: window.location.href
             };
-            if (!navigator.canShare(shareData)) {
-                console.log("can't share");
-                return;
+            if (navigator.share && navigator.canShare(shareData)) {
+                // console.log("(via navigator.share)");
+                navigator
+                    .share({title: document.title, url: window.location.href})
+                    .then(() => {
+                        console.log("Thanks for sharing!");
+                    })
+                    .catch(console.error);
+                }
+            else if (navigator.clipboard) {
+                // console.log("(via navigator.clipboard)");
+                navigator.clipboard.writeText(shareData.url)
+                    .then(() => {
+                        console.log("Thanks for sharing!");
+                    })
+                    .catch(console.error);
             }
-            navigator
-                .share({title: document.title, url: window.location.href})
-                .then(() => {
-                    console.log('Thanks for sharing!');
-                })
-                .catch(console.error);
+            else {
+                console.log("can't share directly, but feel free to copy the url from addressbar manually");
+            }
         }
         shareButton.addEventListener("click", doShareButton);
     </script>


### PR DESCRIPTION
> Uncaught TypeError: navigator.canShare is not a function

![navigator-canshare in firefox](https://github.com/Xe/site/assets/140316503/ddbc8caf-6c2a-4d7a-b951-5321db836493)

`navigator.canShare` is under a [settings flag](https://caniuse.com/mdn-api_navigator_canshare) in firefox, and also completely missing from some other browsers/versions, so we need to check general availability first

this fix will fallback to copying url into clipboard

same should be done for `vod.njk` and `talk.njk`, but maybe you'd want to separate this into its own script-file, so i changed it just in `blog.njk`
