### PR TITLE
Fedora 40 beta is also affected

### DIFF
--- a/lume/src/notes/2024/xz-vuln.mdx
+++ b/lume/src/notes/2024/xz-vuln.mdx
@@ -19,7 +19,7 @@ We are lucky. This only affects AMD64 Linux systems. Currently, incomplete analy
 
 If you are using a distribution that has not yet released xz 5.6.0 or 5.6.1, you are likely safe.
 
-If you are running Debian sid, Fedora 41, Fedora Rawhide, openSUSE Tumbleweed, or openSUSE MicroOS, run updates now.
+If you are running Debian sid, Fedora 40, Fedora Rawhide, openSUSE Tumbleweed, or openSUSE MicroOS, run updates now.
 
 Here are the distros where it is likely to be released (according to [repology](https://repology.org/project/xz/versions)):
 


### PR DESCRIPTION
Fedora 40 beta release is not affected, but update-testing repository is. In my experience is common for beta users to have that repo enabled. I think it's by default but can't confirm.