### PR TITLE
Reference correct Fedora version

### DIFF
--- a/lume/src/notes/2024/xz-vuln.mdx
+++ b/lume/src/notes/2024/xz-vuln.mdx
@@ -19,7 +19,7 @@ We are lucky. This only affects AMD64 Linux systems. Currently, incomplete analy
 
 If you are using a distribution that has not yet released xz 5.6.0 or 5.6.1, you are likely safe.
 
-If you are running Debian sid, Fedora 41, Fedora Rawhide, openSUSE Tumbleweed, or openSUSE MicroOS, run updates now.
+If you are running Debian sid, Fedora 40, Fedora Rawhide, openSUSE Tumbleweed, or openSUSE MicroOS, run updates now.
 
 Here are the distros where it is likely to be released (according to [repology](https://repology.org/project/xz/versions)):
 


### PR DESCRIPTION
Currently Fedora 41 _is_ rawhide. Fedora 40 is the affected branch.
