### PR TITLE
fix: correct spelling in resume

### DIFF
--- a/lume/src/resume.njk
+++ b/lume/src/resume.njk
@@ -51,7 +51,7 @@ layout: base.njk
 
 <p class="mb-4">I regularly write articles and lead internal talks about how to use Tailscale and other technology topics in new and interesting ways.</p>
 
-<h3 class="text-xl mb-4">Lightspeed POS - Expert principal en fiabileté du site</h3>
+<h3 class="text-xl mb-4">Lightspeed POS - Expert principal en fiabilité du site</h3>
 <span class="text-md mb-4">2019-05 - 2020-11, Montréal, CAN</span>
 
 <p class="mb-4">I spearheaded and maintained the internal Kubernetes deployment (with the goal of being functionally an in-house Platform-as-a-service) and all of the assorted tooling around it, helping internal developers deploy new features to customers faster. I also helped to create custom icons and color schemes for internal tools, with the goal of having consistent brand design for knowing which tool is which at a glance.


### PR DESCRIPTION
Corrected a minor spelling error in the job title, probably just a one-off typo.

This ensures the correct French term `fiabilité` (reliability) is used instead of the incorrect `fiabileté`. 

_It ain't much, but it's honest work._