### PR TITLE
Add grafana proxy host forwarding

### DIFF
--- a/lume/src/blog/prometheus-grafana-loki-nixos-2020-11-20.mdx
+++ b/lume/src/blog/prometheus-grafana-loki-nixos-2020-11-20.mdx
@@ -68,6 +68,9 @@ an editor and add the following to it:
     locations."/" = {
         proxyPass = "http://127.0.0.1:${toString config.services.grafana.port}";
         proxyWebsockets = true;
+        extraConfig = ''
+          proxy_set_header Host ${config.services.grafana.domain};
+        '';
     };
   };
 }


### PR DESCRIPTION
Sets the host header for requests to Grafana, as origin requests are required for some endpoints with mutations, namely changing the default account password.

See: https://github.com/grafana/grafana/issues/54641#issuecomment-1236942863