### PR TITLE
feat(sponsor-panel): add Prometheus metrics for SRE observability

### DIFF
--- a/cmd/sponsor-panel/main.go
+++ b/cmd/sponsor-panel/main.go
@@ -285,23 +285,23 @@ func main() {
 	})
 
 	// OAuth handlers
-	mux.HandleFunc("/login", server.loginHandler)
-	mux.HandleFunc("/callback", server.callbackHandler)
-	mux.HandleFunc("/logout", server.logoutHandler)
+	mux.HandleFunc("/login", instrumentHandler("login", server.loginHandler))
+	mux.HandleFunc("/callback", instrumentHandler("callback", server.callbackHandler))
+	mux.HandleFunc("/logout", instrumentHandler("logout", server.logoutHandler))
 
 	// Patreon OAuth handlers
-	mux.HandleFunc("/login/patreon", server.patreonLoginHandler)
-	mux.HandleFunc("/callback/patreon", server.patreonCallbackHandler)
+	mux.HandleFunc("/login/patreon", instrumentHandler("login_patreon", server.patreonLoginHandler))
+	mux.HandleFunc("/callback/patreon", instrumentHandler("callback_patreon", server.patreonCallbackHandler))
 
 	// Login page handler
-	mux.HandleFunc("/login-page", server.loginPageHandler)
+	mux.HandleFunc("/login-page", instrumentHandler("login_page", server.loginPageHandler))
 
 	// Dashboard handler (also serves login page if not authenticated)
-	mux.HandleFunc("/", server.dashboardHandler)
+	mux.HandleFunc("/", instrumentHandler("dashboard", server.dashboardHandler))
 
 	// Feature handlers
-	mux.HandleFunc("/invite", server.inviteHandler)
-	mux.HandleFunc("/logo", server.logoHandler)
+	mux.HandleFunc("/invite", instrumentHandler("invite", server.inviteHandler))
+	mux.HandleFunc("/logo", instrumentHandler("logo", server.logoHandler))
 
 	// Expose Prometheus metrics at /metrics for observability
 	mux.Handle("/metrics", promhttp.Handler())

--- a/cmd/sponsor-panel/metrics.go
+++ b/cmd/sponsor-panel/metrics.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "sponsor_panel_http_request_duration_seconds",
+		Help:    "Duration of HTTP requests by handler, method, and status code.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"handler", "method", "code"})
+
+	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sponsor_panel_http_requests_total",
+		Help: "Total HTTP requests by handler, method, and status code.",
+	}, []string{"handler", "method", "code"})
+
+	httpRequestsInFlight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "sponsor_panel_http_requests_in_flight",
+		Help: "Number of HTTP requests currently being served by handler.",
+	}, []string{"handler"})
+
+	httpResponseSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "sponsor_panel_http_response_size_bytes",
+		Help:    "Size of HTTP responses by handler.",
+		Buckets: []float64{100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000},
+	}, []string{"handler"})
+
+	sponsorSyncDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "sponsor_panel_sync_duration_seconds",
+		Help:    "Duration of sponsor sync operations.",
+		Buckets: []float64{0.5, 1, 2, 5, 10, 30, 60},
+	})
+
+	sponsorSyncTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sponsor_panel_sync_total",
+		Help: "Total sponsor sync operations by result.",
+	}, []string{"result"})
+
+	sponsorSyncActiveSponsors = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "sponsor_panel_active_sponsors",
+		Help: "Number of active sponsors after last sync.",
+	})
+
+	oauthTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sponsor_panel_oauth_total",
+		Help: "Total OAuth login attempts by provider and result.",
+	}, []string{"provider", "result"})
+
+	sessionErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "sponsor_panel_session_errors_total",
+		Help: "Total session decode/retrieval errors.",
+	})
+)
+
+// statusRecorder wraps http.ResponseWriter to capture the status code and bytes written.
+type statusRecorder struct {
+	http.ResponseWriter
+	code         int
+	bytesWritten int
+	wroteHeader  bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if !r.wroteHeader {
+		r.code = code
+		r.wroteHeader = true
+	}
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.code = http.StatusOK
+		r.wroteHeader = true
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytesWritten += n
+	return n, err
+}
+
+// instrumentHandler wraps an http.HandlerFunc with prometheus metrics.
+func instrumentHandler(name string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		inFlight := httpRequestsInFlight.WithLabelValues(name)
+		inFlight.Inc()
+		defer inFlight.Dec()
+
+		rec := &statusRecorder{ResponseWriter: w, code: http.StatusOK}
+		start := time.Now()
+
+		next(rec, r)
+
+		duration := time.Since(start).Seconds()
+		code := strconv.Itoa(rec.code)
+
+		httpRequestDuration.WithLabelValues(name, r.Method, code).Observe(duration)
+		httpRequestsTotal.WithLabelValues(name, r.Method, code).Inc()
+		httpResponseSize.WithLabelValues(name).Observe(float64(rec.bytesWritten))
+	}
+}

--- a/cmd/sponsor-panel/oauth.go
+++ b/cmd/sponsor-panel/oauth.go
@@ -482,6 +482,7 @@ func (s *Server) callbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	state := r.URL.Query().Get("state")
 	if state != stateCookie.Value {
+		oauthTotal.WithLabelValues("github", "error_state_mismatch").Inc()
 		slog.Error("callbackHandler: oauth state mismatch",
 			"query_state", state[:8]+"...",
 			"cookie_state", stateCookie.Value[:8]+"...")
@@ -513,6 +514,7 @@ func (s *Server) callbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	token, err := s.oauth.Exchange(r.Context(), code)
 	if err != nil {
+		oauthTotal.WithLabelValues("github", "error_token_exchange").Inc()
 		slog.Error("callbackHandler: failed to exchange token", "err", err)
 		renderOAuthError(w, "Failed to exchange token")
 		return
@@ -568,6 +570,7 @@ func (s *Server) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := upsertUser(r.Context(), s.pool, user); err != nil {
+		oauthTotal.WithLabelValues("github", "error_upsert").Inc()
 		slog.Error("callbackHandler: failed to upsert user", "err", err, "github_id", ghUser.ID)
 		renderOAuthError(w, "Failed to create user")
 		return
@@ -590,6 +593,7 @@ func (s *Server) callbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	oauthTotal.WithLabelValues("github", "success").Inc()
 	slog.Info("callbackHandler: user logged in successfully", "user_id", user.ID, "login", ghUser.Login)
 
 	// Redirect to dashboard
@@ -635,6 +639,7 @@ func (s *Server) logoutHandler(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getSessionUser(r *http.Request) (*User, error) {
 	session, err := s.sessionStore.Get(r, "session")
 	if err != nil {
+		sessionErrors.Inc()
 		// Failed to decode session - might be old format, try to read raw cookie
 		slog.Debug("getSessionUser: failed to get session, trying old format", "err", err)
 		cookie, err := r.Cookie("session")

--- a/cmd/sponsor-panel/patreon_oauth.go
+++ b/cmd/sponsor-panel/patreon_oauth.go
@@ -136,6 +136,7 @@ func (s *Server) patreonCallbackHandler(w http.ResponseWriter, r *http.Request) 
 
 	token, err := s.patreonOAuth.Exchange(r.Context(), code)
 	if err != nil {
+		oauthTotal.WithLabelValues("patreon", "error_token_exchange").Inc()
 		slog.Error("patreonCallbackHandler: failed to exchange token", "err", err)
 		renderOAuthError(w, "Failed to exchange token")
 		return
@@ -233,6 +234,7 @@ func (s *Server) patreonCallbackHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := upsertPatreonUser(r.Context(), s.pool, user); err != nil {
+		oauthTotal.WithLabelValues("patreon", "error_upsert").Inc()
 		slog.Error("patreonCallbackHandler: failed to upsert user", "err", err, "patreon_id", patreonID)
 		renderOAuthError(w, "Failed to create user")
 		return
@@ -253,6 +255,7 @@ func (s *Server) patreonCallbackHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	oauthTotal.WithLabelValues("patreon", "success").Inc()
 	slog.Info("patreonCallbackHandler: user logged in successfully", "user_id", user.ID, "login", login)
 
 	http.Redirect(w, r, "/", http.StatusFound)

--- a/cmd/sponsor-panel/sync_sponsors.go
+++ b/cmd/sponsor-panel/sync_sponsors.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // graphqlSponsorsResponse represents the GraphQL response for sponsorshipsAsMaintainer.
@@ -42,8 +43,15 @@ type graphqlSponsorsResponse struct {
 }
 
 // syncSponsors performs a single sync of all sponsors from GitHub.
-func syncSponsors(ctx context.Context, pool *pgxpool.Pool, ghToken string) error {
+func syncSponsors(ctx context.Context, pool *pgxpool.Pool, ghToken string) (retErr error) {
 	slog.Info("syncSponsors: starting sponsor sync")
+	timer := prometheus.NewTimer(sponsorSyncDuration)
+	defer func() {
+		timer.ObserveDuration()
+		if retErr != nil {
+			sponsorSyncTotal.WithLabelValues("error").Inc()
+		}
+	}()
 
 	allSponsors := make([]string, 0)
 
@@ -147,6 +155,9 @@ func syncSponsors(ctx context.Context, pool *pgxpool.Pool, ghToken string) error
 		slog.Error("syncSponsors: failed to mark inactive sponsors", "err", err)
 		return err
 	}
+
+	sponsorSyncTotal.WithLabelValues("success").Inc()
+	sponsorSyncActiveSponsors.Set(float64(len(allSponsors)))
 
 	slog.Info("syncSponsors: sync completed",
 		"active_sponsors", len(allSponsors),


### PR DESCRIPTION
## Summary

- Add per-handler HTTP request duration histograms (`sponsor_panel_http_request_duration_seconds`) with handler, method, and status code labels
- Add per-handler failure/success counters (`sponsor_panel_http_requests_total`) and in-flight gauges (`sponsor_panel_http_requests_in_flight`)
- Add response size histograms (`sponsor_panel_http_response_size_bytes`)
- Add sponsor sync metrics: duration histogram, success/error counter, active sponsors gauge
- Add OAuth login counters by provider and result (success, state mismatch, token exchange error, upsert error)
- Add session decode error counter

## Metrics exposed

| Metric | Type | Labels |
|--------|------|--------|
| `sponsor_panel_http_request_duration_seconds` | Histogram | handler, method, code |
| `sponsor_panel_http_requests_total` | Counter | handler, method, code |
| `sponsor_panel_http_requests_in_flight` | Gauge | handler |
| `sponsor_panel_http_response_size_bytes` | Histogram | handler |
| `sponsor_panel_sync_duration_seconds` | Histogram | — |
| `sponsor_panel_sync_total` | Counter | result |
| `sponsor_panel_active_sponsors` | Gauge | — |
| `sponsor_panel_oauth_total` | Counter | provider, result |
| `sponsor_panel_session_errors_total` | Counter | — |

## Test plan

- [ ] `go build ./cmd/sponsor-panel/` passes
- [ ] Verify `/metrics` endpoint exposes new metrics after deploying
- [ ] Confirm handler labels match expected route names in Prometheus/Grafana