### PR TITLE
feat(preview): add erofs-backed content-addressed preview service

### DIFF
--- a/.github/workflows/earthly.yml
+++ b/.github/workflows/earthly.yml
@@ -40,6 +40,7 @@ jobs:
             patreon-saasproxy.tags=ghcr.io/xe/site/patreon-saasproxy:latest
             sponsor-panel.tags=ghcr.io/xe/site/sponsor-panel:latest
             xesite.tags=ghcr.io/xe/site/bin:latest
+            futuresight.tags=ghcr.io/xe/site/futuresight:latest
 
       - name: Build Docker image
         if: github.event_name == 'pull_request'
@@ -51,3 +52,4 @@ jobs:
             patreon-saasproxy.tags=ghcr.io/xe/site/patreon-saasproxy:latest
             sponsor-panel.tags=ghcr.io/xe/site/sponsor-panel:latest
             xesite.tags=ghcr.io/xe/site/bin:latest
+            futuresight.tags=ghcr.io/xe/site/futuresight:latest

--- a/.tekton/test-pipelinerun.yaml
+++ b/.tekton/test-pipelinerun.yaml
@@ -26,9 +26,6 @@ spec:
           resources:
             requests:
               storage: 4Gi
-    - name: go-mod-cache
-      persistentVolumeClaim:
-        claimName: go-mod-cache
     - name: dockerconfig-atcr
       secret:
         secretName: atcr

--- a/.tekton/xe-site-pipeline.yaml
+++ b/.tekton/xe-site-pipeline.yaml
@@ -29,9 +29,6 @@ spec:
     - name: repo-data
       description: |
         Cloned repo files.
-    - name: go-mod-cache
-      description: |
-        Go module cache
     - name: dockerconfig-atcr
       description: |
         Docker config for pushing images to atcr
@@ -80,14 +77,10 @@ spec:
       workspaces:
         - name: source
           workspace: repo-data
-        - name: go-mod-cache
-          workspace: go-mod-cache
       taskSpec:
         workspaces:
           - name: source
             mountPath: /src
-          - name: go-mod-cache
-            mountPath: /go
         steps:
           - name: go-test
             image: $(tasks.docker-build-ci.results.IMAGE_URL)@$(tasks.docker-build-ci.results.IMAGE_DIGEST)
@@ -163,5 +156,26 @@ spec:
             [
               "--destination=$(params.docker-image-base)/bin:$(params.commit)",
               "--destination=$(params.docker-image-base)/bin:$(params.branch)",
+              "--label=org.tangled.actor=$(params.actor)",
+            ]
+    - name: futuresight-build
+      runAfter: ["go-test"]
+      workspaces:
+        - name: source
+          workspace: repo-data
+        - name: dockerconfig
+          workspace: dockerconfig-atcr
+      taskRef:
+        name: kaniko
+      params:
+        - name: IMAGE
+          value: $(params.docker-image-base)/futuresight:latest
+        - name: DOCKERFILE
+          value: ./docker/futuresight.Dockerfile
+        - name: EXTRA_ARGS
+          value:
+            [
+              "--destination=$(params.docker-image-base)/futuresight:$(params.commit)",
+              "--destination=$(params.docker-image-base)/futuresight:$(params.branch)",
               "--label=org.tangled.actor=$(params.actor)",
             ]

--- a/cmd/futuresight/handlers.go
+++ b/cmd/futuresight/handlers.go
@@ -5,20 +5,34 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"errors"
-	"expvar"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	uploads      = expvar.NewInt("gauge_futuresight_uploads")
-	uploadErrors = expvar.NewInt("gauge_futuresight_upload_errors")
-	serves       = expvar.NewInt("gauge_futuresight_serves")
-	notFounds    = expvar.NewInt("gauge_futuresight_not_founds")
+	uploads = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "futuresight_uploads_total",
+		Help: "Number of preview volumes successfully stored.",
+	})
+	uploadErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "futuresight_upload_errors_total",
+		Help: "Number of failed uploads.",
+	})
+	serves = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "futuresight_serves_total",
+		Help: "Number of preview volumes successfully served.",
+	})
+	notFounds = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "futuresight_not_founds_total",
+		Help: "Number of requests for previews that could not be resolved.",
+	})
 )
 
 // server holds the shared dependencies for the preview HTTP handlers.
@@ -46,7 +60,7 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, s.maxUploadBytes)
 
 	if err := r.ParseMultipartForm(8 << 20); err != nil {
-		uploadErrors.Add(1)
+		uploadErrors.Inc()
 		var tooLarge *http.MaxBytesError
 		if errors.As(err, &tooLarge) {
 			http.Error(w, "upload too large", http.StatusRequestEntityTooLarge)
@@ -58,7 +72,7 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 
 	file, _, err := r.FormFile("file")
 	if err != nil {
-		uploadErrors.Add(1)
+		uploadErrors.Inc()
 		http.Error(w, "missing file", http.StatusBadRequest)
 		return
 	}
@@ -70,7 +84,7 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	// authoritative on the content address.
 	tmp, err := os.CreateTemp(s.store.cacheDir, "upload.*.erofs")
 	if err != nil {
-		uploadErrors.Add(1)
+		uploadErrors.Inc()
 		slog.Error("can't create temp upload", "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
@@ -81,14 +95,14 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.Copy(io.MultiWriter(tmp, h), file); err != nil {
 		tmp.Close()
 		os.Remove(tmpName)
-		uploadErrors.Add(1)
+		uploadErrors.Inc()
 		slog.Error("can't read upload", "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpName)
-		uploadErrors.Add(1)
+		uploadErrors.Inc()
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
@@ -97,7 +111,7 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store.PutVolume(r.Context(), hash, tmpName); err != nil {
 		os.Remove(tmpName)
-		uploadErrors.Add(1)
+		uploadErrors.Inc()
 		slog.Error("can't store volume", "err", err, "hash", hash)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
@@ -113,14 +127,14 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	slug := slugifyBranch(branch)
 	if slug != "" {
 		if err := s.store.SetBranch(r.Context(), slug, hash); err != nil {
-			uploadErrors.Add(1)
+			uploadErrors.Inc()
 			slog.Error("can't set branch pointer", "err", err, "slug", slug, "hash", hash)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
 	}
 
-	uploads.Add(1)
+	uploads.Inc()
 	slog.Info("stored preview", "hash", hash, "branch", branch, "slug", slug)
 
 	w.Header().Set("Content-Type", "text/plain")
@@ -132,7 +146,7 @@ func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
 func (s *server) handleServe(w http.ResponseWriter, r *http.Request) {
 	label, ok := subdomainLabel(r.Host, s.baseDomain)
 	if !ok {
-		notFounds.Add(1)
+		notFounds.Inc()
 		http.NotFound(w, r)
 		return
 	}
@@ -142,7 +156,7 @@ func (s *server) handleServe(w http.ResponseWriter, r *http.Request) {
 		resolved, err := s.store.ResolveBranch(r.Context(), label)
 		if err != nil {
 			if errors.Is(err, ErrNotFound) {
-				notFounds.Add(1)
+				notFounds.Inc()
 				http.Error(w, "no such preview", http.StatusNotFound)
 				return
 			}
@@ -156,7 +170,7 @@ func (s *server) handleServe(w http.ResponseWriter, r *http.Request) {
 	volFS, err := s.store.Volume(r.Context(), hash)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			notFounds.Add(1)
+			notFounds.Inc()
 			http.Error(w, "no such preview", http.StatusNotFound)
 			return
 		}
@@ -165,7 +179,7 @@ func (s *server) handleServe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	serves.Add(1)
+	serves.Inc()
 	http.FileServerFS(volFS).ServeHTTP(w, r)
 }
 

--- a/cmd/futuresight/handlers.go
+++ b/cmd/futuresight/handlers.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"expvar"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+var (
+	uploads      = expvar.NewInt("gauge_futuresight_uploads")
+	uploadErrors = expvar.NewInt("gauge_futuresight_upload_errors")
+	serves       = expvar.NewInt("gauge_futuresight_serves")
+	notFounds    = expvar.NewInt("gauge_futuresight_not_founds")
+)
+
+// server holds the shared dependencies for the preview HTTP handlers.
+type server struct {
+	store          *Store
+	baseDomain     string
+	uploadToken    string
+	maxUploadBytes int64
+}
+
+// handleUpload receives an erofs volume, stores it under its content hash in
+// Tigris, and points the build's branch slug at that hash.
+func (s *server) handleUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !s.authorized(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Bound the upload before reading any of it; this endpoint is public.
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxUploadBytes)
+
+	if err := r.ParseMultipartForm(8 << 20); err != nil {
+		uploadErrors.Add(1)
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			http.Error(w, "upload too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		http.Error(w, "bad multipart form", http.StatusBadRequest)
+		return
+	}
+
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		uploadErrors.Add(1)
+		http.Error(w, "missing file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	branch := r.FormValue("branch")
+
+	// Stream the volume to a temp file while hashing so the server is
+	// authoritative on the content address.
+	tmp, err := os.CreateTemp(s.store.cacheDir, "upload.*.erofs")
+	if err != nil {
+		uploadErrors.Add(1)
+		slog.Error("can't create temp upload", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	tmpName := tmp.Name()
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), file); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		uploadErrors.Add(1)
+		slog.Error("can't read upload", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		uploadErrors.Add(1)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	hash := hex.EncodeToString(h.Sum(nil))[:hashLen]
+
+	if err := s.store.PutVolume(r.Context(), hash, tmpName); err != nil {
+		os.Remove(tmpName)
+		uploadErrors.Add(1)
+		slog.Error("can't store volume", "err", err, "hash", hash)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Prime the local cache so the first request for this hash skips the
+	// download round-trip.
+	if err := os.Rename(tmpName, s.store.CachePath(hash)); err != nil {
+		os.Remove(tmpName)
+		slog.Warn("can't prime cache", "err", err, "hash", hash)
+	}
+
+	slug := slugifyBranch(branch)
+	if slug != "" {
+		if err := s.store.SetBranch(r.Context(), slug, hash); err != nil {
+			uploadErrors.Add(1)
+			slog.Error("can't set branch pointer", "err", err, "slug", slug, "hash", hash)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	uploads.Add(1)
+	slog.Info("stored preview", "hash", hash, "branch", branch, "slug", slug)
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, hash+"\n")
+}
+
+// handleServe resolves the request's subdomain label to a volume and serves it.
+func (s *server) handleServe(w http.ResponseWriter, r *http.Request) {
+	label, ok := subdomainLabel(r.Host, s.baseDomain)
+	if !ok {
+		notFounds.Add(1)
+		http.NotFound(w, r)
+		return
+	}
+
+	hash := label
+	if !isHash(label) {
+		resolved, err := s.store.ResolveBranch(r.Context(), label)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				notFounds.Add(1)
+				http.Error(w, "no such preview", http.StatusNotFound)
+				return
+			}
+			slog.Error("can't resolve branch", "err", err, "slug", label)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		hash = resolved
+	}
+
+	volFS, err := s.store.Volume(r.Context(), hash)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			notFounds.Add(1)
+			http.Error(w, "no such preview", http.StatusNotFound)
+			return
+		}
+		slog.Error("can't open volume", "err", err, "hash", hash)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	serves.Add(1)
+	http.FileServerFS(volFS).ServeHTTP(w, r)
+}
+
+// authorized reports whether the request carries the configured upload token. An
+// empty configured token disables auth (intended for local development).
+func (s *server) authorized(r *http.Request) bool {
+	if s.uploadToken == "" {
+		return true
+	}
+
+	const prefix = "Bearer "
+	got := r.Header.Get("Authorization")
+	if !strings.HasPrefix(got, prefix) {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare([]byte(got[len(prefix):]), []byte(s.uploadToken)) == 1
+}
+
+// subdomainLabel returns the single leftmost label of host below baseDomain, or
+// false if host is not a direct subdomain of baseDomain.
+func subdomainLabel(host, baseDomain string) (string, bool) {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(host)
+
+	suffix := "." + baseDomain
+	if !strings.HasSuffix(host, suffix) {
+		return "", false
+	}
+
+	label := strings.TrimSuffix(host, suffix)
+	if label == "" || strings.Contains(label, ".") {
+		return "", false
+	}
+
+	return label, true
+}
+
+// isHash reports whether label is exactly a content hash: hashLen lowercase hex
+// characters.
+func isHash(label string) bool {
+	if len(label) != hashLen {
+		return false
+	}
+	for _, r := range label {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/futuresight/handlers_test.go
+++ b/cmd/futuresight/handlers_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleUploadTooLarge(t *testing.T) {
+	t.Parallel()
+
+	// Build a multipart body larger than the cap.
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	part, err := w.CreateFormFile("file", "site.erofs")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	part.Write(make([]byte, 4096))
+	w.Close()
+
+	srv := &server{maxUploadBytes: 1024} // empty token => auth disabled
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", &buf)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	srv.handleUpload(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestHandleUploadUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv := &server{maxUploadBytes: 1 << 20, uploadToken: "secret"}
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleUpload(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestSubdomainLabel(t *testing.T) {
+	t.Parallel()
+
+	const base = "preview.xeiaso.net"
+
+	for _, tt := range []struct {
+		name   string
+		host   string
+		want   string
+		wantOK bool
+	}{
+		{name: "hash label", host: "0123456789abcdef.preview.xeiaso.net", want: "0123456789abcdef", wantOK: true},
+		{name: "branch label", host: "main.preview.xeiaso.net", want: "main", wantOK: true},
+		{name: "with port", host: "main.preview.xeiaso.net:3000", want: "main", wantOK: true},
+		{name: "uppercase normalized", host: "Main.Preview.Xeiaso.Net", want: "main", wantOK: true},
+		{name: "apex is not a subdomain", host: "preview.xeiaso.net", wantOK: false},
+		{name: "unrelated domain", host: "xeiaso.net", wantOK: false},
+		{name: "multi-level label rejected", host: "a.b.preview.xeiaso.net", wantOK: false},
+		{name: "empty label rejected", host: ".preview.xeiaso.net", wantOK: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := subdomainLabel(tt.host, base)
+			if ok != tt.wantOK {
+				t.Fatalf("subdomainLabel(%q) ok = %v, want %v", tt.host, ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("subdomainLabel(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHash(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		label string
+		want  bool
+	}{
+		{name: "valid 16 hex", label: "0123456789abcdef", want: true},
+		{name: "too short", label: "0123", want: false},
+		{name: "too long", label: "0123456789abcdef0", want: false},
+		{name: "uppercase hex rejected", label: "0123456789ABCDEF", want: false},
+		{name: "non-hex char", label: "0123456789abcdeg", want: false},
+		{name: "branch name", label: "main", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isHash(tt.label); got != tt.want {
+				t.Errorf("isHash(%q) = %v, want %v", tt.label, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/futuresight/main.go
+++ b/cmd/futuresight/main.go
@@ -1,0 +1,123 @@
+// Command futuresight is the xesite preview server. It stores each build's erofs
+// volume in Tigris and serves every version on its own subdomain: a permanent
+// host keyed by the truncated sha256 of the volume, and a moving host keyed by a
+// DNS-safe slug of the git branch.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"expvar"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"net"
+	"net/http"
+
+	"github.com/facebookgo/flagenv"
+	_ "github.com/joho/godotenv/autoload"
+	storage "github.com/tigrisdata/storage-go"
+	"xeiaso.net/v4/internal"
+)
+
+// hashLen must match internal/lume's hashLen: the number of hex characters that
+// content-address a volume (and form a permanent subdomain label).
+const hashLen = 16
+
+var (
+	bind            = flag.String("bind", ":3000", "Port to listen on")
+	internalAPIBind = flag.String("internal-api-bind", ":3001", "Port to listen on for the internal API")
+	baseDomain      = flag.String("base-domain", "preview.xeiaso.net", "Base domain; the leftmost label selects the preview")
+	cacheDir        = flag.String("cache-dir", "./var/volumes", "Directory to cache downloaded erofs volumes")
+	tigrisBucket    = flag.String("tigris-bucket", "", "Tigris bucket to store preview volumes in")
+	accessKeyID     = flag.String("tigris-access-key-id", "", "Tigris access key ID (falls back to AWS_ACCESS_KEY_ID)")
+	secretAccessKey = flag.String("tigris-secret-access-key", "", "Tigris secret access key (falls back to AWS_SECRET_ACCESS_KEY)")
+	uploadToken     = flag.String("upload-token", "", "Bearer token required to POST /upload")
+	maxUploadBytes  = flag.Int64("max-upload-bytes", 512<<20, "Maximum accepted upload size in bytes")
+	generateToken   = flag.Bool("generate-token", false, "Print a random upload token and exit")
+)
+
+// randomToken returns a 32-byte cryptographically random token as hex.
+func randomToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("futuresight: can't generate token: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func main() {
+	flagenv.Parse()
+	flag.Parse()
+	internal.Slog()
+
+	if *generateToken {
+		token, err := randomToken()
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(token)
+		return
+	}
+
+	ctx := context.Background()
+
+	if *tigrisBucket == "" {
+		log.Fatal("--tigris-bucket is required")
+	}
+
+	opts := []storage.Option{storage.WithGlobalEndpoint()}
+	if *accessKeyID != "" && *secretAccessKey != "" {
+		opts = append(opts, storage.WithAccessKeypair(*accessKeyID, *secretAccessKey))
+	}
+
+	client, err := storage.New(ctx, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	store, err := NewStore(client, *tigrisBucket, *cacheDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	srv := &server{
+		store:          store,
+		baseDomain:     *baseDomain,
+		uploadToken:    *uploadToken,
+		maxUploadBytes: *maxUploadBytes,
+	}
+
+	go internalAPI()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/upload", srv.handleUpload)
+	mux.HandleFunc("/", srv.handleServe)
+
+	ln, err := net.Listen("tcp", *bind)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	slog.Info("starting futuresight", "bind", *bind, "base-domain", *baseDomain, "bucket", *tigrisBucket)
+	log.Fatal(http.Serve(ln, mux))
+}
+
+func internalAPI() {
+	mux := http.NewServeMux()
+	mux.Handle("/debug/vars", expvar.Handler())
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "OK")
+	})
+
+	ln, err := net.Listen("tcp", *internalAPIBind)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := http.Serve(ln, mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/futuresight/main.go
+++ b/cmd/futuresight/main.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"expvar"
 	"flag"
 	"fmt"
 	"log"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/facebookgo/flagenv"
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	storage "github.com/tigrisdata/storage-go"
 	"xeiaso.net/v4/internal"
 )
@@ -107,7 +107,7 @@ func main() {
 
 func internalAPI() {
 	mux := http.NewServeMux()
-	mux.Handle("/debug/vars", expvar.Handler())
+	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "OK")
 	})

--- a/cmd/futuresight/slug.go
+++ b/cmd/futuresight/slug.go
@@ -1,0 +1,37 @@
+package main
+
+import "strings"
+
+// dnsLabelMax is the maximum length of a single DNS label (RFC 1035).
+const dnsLabelMax = 63
+
+// slugifyBranch converts a git branch name into a DNS-safe label: lowercase
+// ASCII alphanumerics, with every other run of characters collapsed to a single
+// hyphen, trimmed of leading/trailing hyphens, and truncated to one DNS label.
+//
+//	feat/Foo_Bar -> feat-foo-bar
+func slugifyBranch(branch string) string {
+	var b strings.Builder
+	lastHyphen := true // leading hyphens are trimmed
+
+	for _, r := range strings.ToLower(branch) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastHyphen = false
+		default:
+			if !lastHyphen {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		}
+	}
+
+	slug := strings.TrimRight(b.String(), "-")
+
+	if len(slug) > dnsLabelMax {
+		slug = strings.TrimRight(slug[:dnsLabelMax], "-")
+	}
+
+	return slug
+}

--- a/cmd/futuresight/slug_test.go
+++ b/cmd/futuresight/slug_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSlugifyBranch(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		branch string
+		want   string
+	}{
+		{name: "simple", branch: "main", want: "main"},
+		{name: "slash", branch: "feat/erofs", want: "feat-erofs"},
+		{name: "mixed case and underscore", branch: "feat/Foo_Bar", want: "feat-foo-bar"},
+		{name: "collapses runs", branch: "a//__b", want: "a-b"},
+		{name: "trims leading and trailing junk", branch: "--Hello--", want: "hello"},
+		{name: "unicode dropped", branch: "feat/café", want: "feat-caf"},
+		{name: "digits kept", branch: "release-4.6.1", want: "release-4-6-1"},
+		{name: "all junk", branch: "///", want: ""},
+		{name: "empty", branch: "", want: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := slugifyBranch(tt.branch)
+			if got != tt.want {
+				t.Errorf("slugifyBranch(%q) = %q, want %q", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugifyBranchTruncates(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 100)
+	got := slugifyBranch(long)
+
+	if len(got) > dnsLabelMax {
+		t.Errorf("slug length = %d, want <= %d", len(got), dnsLabelMax)
+	}
+}

--- a/cmd/futuresight/store.go
+++ b/cmd/futuresight/store.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/Xe/erofs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	storage "github.com/tigrisdata/storage-go"
+)
+
+// ErrNotFound is returned when a requested volume or branch pointer does not
+// exist in Tigris.
+var ErrNotFound = errors.New("futuresight: not found")
+
+const (
+	volumePrefix = "volumes/"
+	branchPrefix = "branches/"
+)
+
+// openVolume bundles an opened erofs filesystem with the file handle it reads
+// from so the descriptor can be released on close.
+type openVolume struct {
+	fs *erofs.FS
+	f  *os.File
+}
+
+// Store persists erofs volumes in Tigris and serves them from a local disk
+// cache. Volumes are content-addressed and therefore immutable, so cached
+// handles are kept open for the lifetime of the process.
+type Store struct {
+	client   *storage.Client
+	bucket   string
+	cacheDir string
+
+	mu     sync.RWMutex
+	opened map[string]*openVolume
+}
+
+// NewStore constructs a Store backed by the given Tigris client and bucket,
+// caching downloaded volumes under cacheDir.
+func NewStore(client *storage.Client, bucket, cacheDir string) (*Store, error) {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("futuresight: can't create cache dir %s: %w", cacheDir, err)
+	}
+
+	return &Store{
+		client:   client,
+		bucket:   bucket,
+		cacheDir: cacheDir,
+		opened:   make(map[string]*openVolume),
+	}, nil
+}
+
+// CachePath returns the on-disk cache path for a volume hash.
+func (s *Store) CachePath(hash string) string {
+	return filepath.Join(s.cacheDir, hash+".erofs")
+}
+
+// PutVolume uploads a volume from the file at path under its content hash.
+func (s *Store) PutVolume(ctx context.Context, hash, path string) error {
+	fin, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("futuresight: can't open volume %s: %w", path, err)
+	}
+	defer fin.Close()
+
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucket),
+		Key:         aws.String(volumePrefix + hash + ".erofs"),
+		Body:        fin,
+		ContentType: aws.String("application/octet-stream"),
+	})
+	if err != nil {
+		return fmt.Errorf("futuresight: can't upload volume %s: %w", hash, err)
+	}
+
+	return nil
+}
+
+// SetBranch points a branch slug at a volume hash.
+func (s *Store) SetBranch(ctx context.Context, slug, hash string) error {
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucket),
+		Key:         aws.String(branchPrefix + slug),
+		Body:        strings.NewReader(hash),
+		ContentType: aws.String("text/plain"),
+	})
+	if err != nil {
+		return fmt.Errorf("futuresight: can't set branch %s: %w", slug, err)
+	}
+
+	return nil
+}
+
+// ResolveBranch returns the volume hash a branch slug currently points at.
+func (s *Store) ResolveBranch(ctx context.Context, slug string) (string, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(branchPrefix + slug),
+	})
+	if err != nil {
+		if isNoSuchKey(err) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("futuresight: can't resolve branch %s: %w", slug, err)
+	}
+	defer out.Body.Close()
+
+	data, err := io.ReadAll(out.Body)
+	if err != nil {
+		return "", fmt.Errorf("futuresight: can't read branch pointer %s: %w", slug, err)
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}
+
+// Volume returns the filesystem for a content hash, downloading and caching the
+// volume from Tigris on first use. It returns ErrNotFound if no such volume
+// exists.
+func (s *Store) Volume(ctx context.Context, hash string) (fs.FS, error) {
+	s.mu.RLock()
+	if v, ok := s.opened[hash]; ok {
+		s.mu.RUnlock()
+		return v.fs, nil
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Re-check now that we hold the write lock.
+	if v, ok := s.opened[hash]; ok {
+		return v.fs, nil
+	}
+
+	cachePath := filepath.Join(s.cacheDir, hash+".erofs")
+	if _, err := os.Stat(cachePath); errors.Is(err, os.ErrNotExist) {
+		if err := s.download(ctx, hash, cachePath); err != nil {
+			return nil, err
+		}
+	}
+
+	fin, err := os.Open(cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("futuresight: can't open cached volume %s: %w", hash, err)
+	}
+
+	efs, err := erofs.Open(fin)
+	if err != nil {
+		fin.Close()
+		return nil, fmt.Errorf("futuresight: can't read volume %s: %w", hash, err)
+	}
+
+	s.opened[hash] = &openVolume{fs: efs, f: fin}
+	return efs, nil
+}
+
+// download streams a volume from Tigris to a temp file and atomically renames it
+// into place so a crash mid-download cannot leave a truncated volume.
+func (s *Store) download(ctx context.Context, hash, cachePath string) error {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(volumePrefix + hash + ".erofs"),
+	})
+	if err != nil {
+		if isNoSuchKey(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("futuresight: can't download volume %s: %w", hash, err)
+	}
+	defer out.Body.Close()
+
+	tmp, err := os.CreateTemp(s.cacheDir, hash+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("futuresight: can't create temp volume: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := io.Copy(tmp, out.Body); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("futuresight: can't write volume %s: %w", hash, err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("futuresight: can't close temp volume: %w", err)
+	}
+
+	if err := os.Rename(tmpName, cachePath); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("futuresight: can't finalize volume %s: %w", hash, err)
+	}
+
+	return nil
+}
+
+// isNoSuchKey reports whether err indicates a missing S3 object.
+func isNoSuchKey(err error) bool {
+	var nsk *s3types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return true
+	}
+	var nf *s3types.NotFound
+	return errors.As(err, &nf)
+}

--- a/cmd/futuresight/store_test.go
+++ b/cmd/futuresight/store_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Xe/erofs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	storage "github.com/tigrisdata/storage-go"
+)
+
+// skipIfNoTigris skips integration tests unless a test bucket is configured.
+// Run with: FUTURESIGHT_TEST_BUCKET=xesite-future-sight AWS_PROFILE=tigris go test ./cmd/futuresight -run Integration
+func skipIfNoTigris(t *testing.T) string {
+	t.Helper()
+
+	bucket := os.Getenv("FUTURESIGHT_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("skipping: FUTURESIGHT_TEST_BUCKET not set")
+	}
+	return bucket
+}
+
+// buildTestVolume writes a one-block EROFS volume containing index.html and
+// returns its path.
+func buildTestVolume(t *testing.T, body string) string {
+	t.Helper()
+
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "index.html"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "site.erofs")
+	fout, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	if err := fout.Truncate(4096); err != nil {
+		t.Fatalf("truncate volume: %v", err)
+	}
+
+	b := erofs.NewBuilder(fout, erofs.WithEpoch(time.Unix(1700000000, 0)))
+	if err := b.AddFromFS(os.DirFS(srcDir)); err != nil {
+		t.Fatalf("add fs: %v", err)
+	}
+	if err := b.Build(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := fout.Close(); err != nil {
+		t.Fatalf("close volume: %v", err)
+	}
+
+	return path
+}
+
+func TestStoreIntegration(t *testing.T) {
+	bucket := skipIfNoTigris(t)
+	ctx := context.Background()
+
+	client, err := storage.New(ctx, storage.WithGlobalEndpoint())
+	if err != nil {
+		t.Fatalf("storage.New: %v", err)
+	}
+
+	store, err := NewStore(client, bucket, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	const (
+		hash = "00112233aabbccdd"
+		slug = "futuresight-integration-test"
+		body = "<h1>integration</h1>"
+	)
+
+	volumePath := buildTestVolume(t, body)
+
+	// Clean up the objects we create so the bucket doesn't accumulate test data.
+	t.Cleanup(func() {
+		for _, key := range []string{volumePrefix + hash + ".erofs", branchPrefix + slug} {
+			_, err := client.DeleteObject(ctx, &s3.DeleteObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			})
+			if err != nil {
+				t.Logf("cleanup %s: %v", key, err)
+			}
+		}
+	})
+
+	if err := store.PutVolume(ctx, hash, volumePath); err != nil {
+		t.Fatalf("PutVolume: %v", err)
+	}
+
+	if err := store.SetBranch(ctx, slug, hash); err != nil {
+		t.Fatalf("SetBranch: %v", err)
+	}
+
+	gotHash, err := store.ResolveBranch(ctx, slug)
+	if err != nil {
+		t.Fatalf("ResolveBranch: %v", err)
+	}
+	if gotHash != hash {
+		t.Errorf("ResolveBranch = %q, want %q", gotHash, hash)
+	}
+
+	// Fresh store with an empty cache dir to force a download from Tigris.
+	fresh, err := NewStore(client, bucket, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore (fresh): %v", err)
+	}
+
+	volFS, err := fresh.Volume(ctx, hash)
+	if err != nil {
+		t.Fatalf("Volume: %v", err)
+	}
+
+	got, err := fs.ReadFile(volFS, "index.html")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("served body = %q, want %q", got, body)
+	}
+}
+
+func TestResolveBranchNotFound(t *testing.T) {
+	bucket := skipIfNoTigris(t)
+	ctx := context.Background()
+
+	client, err := storage.New(ctx, storage.WithGlobalEndpoint())
+	if err != nil {
+		t.Fatalf("storage.New: %v", err)
+	}
+
+	store, err := NewStore(client, bucket, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if _, err := store.ResolveBranch(ctx, "does-not-exist-branch-slug"); err != ErrNotFound {
+		t.Errorf("ResolveBranch error = %v, want ErrNotFound", err)
+	}
+}

--- a/cmd/xesite/main.go
+++ b/cmd/xesite/main.go
@@ -26,6 +26,7 @@ var (
 	devel               = flag.Bool("devel", false, "Enable development mode")
 	dataDir             = flag.String("data-dir", "./var", "Directory to store data in")
 	futureSightURL      = flag.String("future-sight-url", "", "URL to use for future sight preview deploys")
+	futureSightToken    = flag.String("future-sight-token", "", "Bearer token for future sight preview uploads")
 	gitBranch           = flag.String("git-branch", "main", "Git branch to clone")
 	gitRepo             = flag.String("git-repo", "https://github.com/Xe/site", "Git repository to clone")
 	githubSecret        = flag.String("github-secret", "", "GitHub secret to use for webhooks")
@@ -56,15 +57,16 @@ func main() {
 	}
 
 	fs, err := lume.New(ctx, &lume.Options{
-		Branch:         *gitBranch,
-		Repo:           *gitRepo,
-		StaticSiteDir:  "lume",
-		URL:            *siteURL,
-		Development:    *devel,
-		PatreonClient:  pc,
-		DataDir:        *dataDir,
-		MiURL:          *miURL,
-		FutureSightURL: *futureSightURL,
+		Branch:           *gitBranch,
+		Repo:             *gitRepo,
+		StaticSiteDir:    "lume",
+		URL:              *siteURL,
+		Development:      *devel,
+		PatreonClient:    pc,
+		DataDir:          *dataDir,
+		MiURL:            *miURL,
+		FutureSightURL:   *futureSightURL,
+		FutureSightToken: *futureSightToken,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,7 +12,7 @@ variable "TYPST_VERSION" { default = "0.13.1" }
 variable "UBUNTU_VERSION" { default = "24.04" }
 
 group "default" {
-  targets = [ "patreon-saasproxy", "xesite", "sponsor-panel" ]
+  targets = [ "patreon-saasproxy", "xesite", "sponsor-panel", "futuresight" ]
 }
 
 target "patreon-saasproxy" {
@@ -63,5 +63,19 @@ target "sponsor-panel" {
   pull = true
   tags = [
     "registry.int.xeserv.us/xe/site/sponsor-panel:main"
+  ]
+}
+
+target "futuresight" {
+  args = {
+    ALPINE_VERSION = null
+    GO_VERSION = null
+  }
+  context = "."
+  dockerfile = "./docker/futuresight.Dockerfile"
+  platforms = [ "linux/amd64", "linux/arm64" ]
+  pull = true
+  tags = [
+    "registry.int.xeserv.us/xe/site/futuresight:main"
   ]
 }

--- a/docker/futuresight.Dockerfile
+++ b/docker/futuresight.Dockerfile
@@ -1,0 +1,32 @@
+ARG GO_VERSION=1.26
+ARG ALPINE_VERSION=edge
+
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS build
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN apk -U add git
+
+RUN --mount=type=cache,target=/root/.cache GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags="-X xeiaso.net/v4.Version=$(git describe --tags --always --dirty)" -o /app/bin/futuresight ./cmd/futuresight
+
+FROM alpine:${ALPINE_VERSION} AS run
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=build /app/bin/futuresight /app/bin/futuresight
+
+EXPOSE 3000
+
+CMD ["/app/bin/futuresight"]
+
+LABEL org.opencontainers.image.source="https://tangled.org/xeiaso.net/site"
+LABEL org.opencontainers.image.title="FutureSight Preview Service"
+LABEL org.opencontainers.image.description="Serves content-addressed xesite preview builds from erofs volumes stored in Tigris"

--- a/docs/superpowers/plans/2026-06-01-erofs-serving.md
+++ b/docs/superpowers/plans/2026-06-01-erofs-serving.md
@@ -1,0 +1,283 @@
+# Plan: erofs-backed serving + content-addressed preview site
+
+> **Status:** implemented on branch `feat/erofs-serving-preview` (uncommitted).
+> This doc has been reconciled with the final implementation; notable deviations
+> from the original plan (non-reproducible volumes, sub-block pre-size fix,
+> server-authoritative hashing, dev-mode branch discovery) are called out inline.
+
+## Context
+
+Today `internal/lume` builds the site with Deno/Lume into `lume/_site`, zips it
+to `var/site.zip`, and serves the live site by swapping `f.fs = os.DirFS(destDir)`
+(`internal/lume/lume.go:374`). A separate external "FutureSight" service receives
+`site.zip` via a multipart POST to `{FutureSightURL}/upload` (`lume.go:651`) for
+previews. There is no content addressing — only the git SHA is tracked.
+
+We want two things:
+
+1. **Build and serve xesite assets through `github.com/Xe/erofs`** (already an
+   indirect dep at v0.4.0; pure Go, no external tools). The built site becomes a
+   single immutable EROFS volume that `internal/lume.FS` serves via `fs.FS`.
+2. **A content-addressed preview site**: a new standalone binary stores each
+   build's erofs volume in Tigris (`github.com/tigrisdata/storage-go`) and serves
+   each version on its own subdomain — a **permanent** host keyed by the truncated
+   sha256 of the volume, plus a **moving** host keyed by a DNS-safe slug of the
+   git branch.
+
+`erofs.FS` implements `fs.FS`, so it drops into the existing `f.fs` slot with no
+change to the HTTP serving path (`http.FileServerFS(fs)` in `cmd/xesite/main.go:86`).
+
+## Relevant APIs (verified via `go doc`)
+
+**erofs** (`github.com/Xe/erofs`):
+
+- `NewBuilder(w io.WriterAt, opts ...BuildOption) *Builder`
+- `(*Builder).AddFromFS(fsys fs.FS) error` — walks an `fs.FS`, adds every entry
+- `(*Builder).Build() error` — finalizes
+- `WithEpoch(t time.Time)`, `WithCompression(alg)` (`CompressionAutoLZ4` / `CompressionNone`)
+- `Open(r io.ReaderAt) (*FS, error)` — returns an `fs.FS` (also `StatFS`)
+
+**storage-go** (`github.com/tigrisdata/storage-go`): `type Client struct{ *s3.Client }`
+
+- `New(ctx, ...Option) (*Client, error)`; `WithAccessKeypair(id, secret)`,
+  `WithGlobalEndpoint()` (default endpoint `https://t3.storage.dev`). `New` calls
+  `awsConfig.LoadDefaultConfig`, so it also picks up `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY` from the environment.
+- Because it embeds `*s3.Client`, use standard `PutObject`, `GetObject`,
+  `HeadObject`, `ListObjectsV2`. `GetObject().Body` is an `io.ReadCloser` (NOT an
+  `io.ReaderAt`), so volumes are read fully into a `bytes.Reader` before
+  `erofs.Open`.
+
+---
+
+## Part A — Build & serve via erofs (`internal/lume`)
+
+### A1. New file `internal/lume/erofs.go`
+
+- `func buildEROFS(srcDir, destPath string, epoch time.Time) (hash string, err error)`:
+  1. `fout, err := os.Create(destPath)` (an `*os.File` satisfies `io.WriterAt`),
+     then `fout.Truncate(4096)` to pre-size to one block. **Why:** `Build()` reads
+     the whole first block back to checksum the superblock, and `*os.File.ReadAt`
+     returns `io.EOF` on a sub-block-sized image. The real site is megabytes so this
+     only matters for tiny inputs (e.g. tests), and EROFS images are block-aligned
+     anyway, so the padding is part of a valid image. (The library's own tests use a
+     zero-padding in-memory buffer and never hit this.)
+  2. `b := erofs.NewBuilder(fout, erofs.WithEpoch(epoch), erofs.WithCompression(erofs.CompressionAutoLZ4))`.
+  3. `b.AddFromFS(os.DirFS(srcDir))`, then `b.Build()`, then close `fout`.
+  4. Reopen the finished file and stream it through `sha256.New()`, returning the
+     first `hashLen` hex chars (`const hashLen = 16`, 64 bits — short enough for a
+     DNS label, wide enough to avoid collisions across builds). Hash the **volume
+     bytes**, per the requirement.
+- `type erofsFS struct { *erofs.FS; f *os.File }` with `func (e *erofsFS) Close() error { return e.f.Close() }`.
+  The existing swap logic already closes the old `f.fs` if it is an `io.Closer`
+  (`lume.go:94`, `lume.go:368`), so wrapping the file handle here makes the handle
+  lifecycle correct without touching that logic.
+- `func openEROFS(path string) (*erofsFS, error)`: `os.Open` → `erofs.Open(f)` →
+  wrap. The `*os.File` is the `io.ReaderAt`; erofs reads lazily so the handle stays
+  open for the FS lifetime.
+
+### A2. Wire into `build()` (`internal/lume/lume.go:333`)
+
+Replace the tail of `build()` (currently lines 362–374, the `ZipFolder` + `os.DirFS`
+swap):
+
+- Build the volume to `filepath.Join(f.opt.DataDir, "site.erofs")` using `buildEROFS`,
+  passing `begin` (the build start time) as the epoch (inode mtimes). Note: the
+  volume is **not** byte-reproducible — the EROFS superblock embeds `time.Now()`
+  and the builder lays out directory entries in map order — so each build gets its
+  own content address. Open the new volume *before* closing the old `f.fs` so a
+  failed open keeps the previous build serving.
+- Store the returned hash on the struct: add `volumeHash string` to `FS`
+  (`lume.go:74`), guarded by the existing `f.lock`.
+- Close the old `f.fs` (keep existing `io.Closer` block), then
+  `f.fs = openEROFS(volumePath)`.
+- **Zip pipeline:** the user chose "replace zip for serving." Keep `ZipFolder`/
+  `site.zip` generation only if the internal `/zip` endpoint
+  (`cmd/xesite/internalapi.go:34`) must keep working; otherwise drop it. Recommended:
+  keep `ZipFolder` writing `site.zip` for that download endpoint (cheap, isolated),
+  but remove zip from the serving path. `zip.go`'s `ZipServer` type is already
+  unused and can be deleted.
+
+### A3. Expose metadata for the preview upload
+
+- `func (f *FS) VolumeHash() string` (lock-guarded getter) — mirrors `Commit()`.
+- `func (f *FS) Branch() string` returns `f.opt.Branch`.
+
+### A3a. Dev-mode branch discovery
+
+In dev mode the build reads the working tree (`fs.repoDir = os.Getwd()`) but
+`f.opt.Branch` would otherwise stay pinned to the `--git-branch` flag (default
+`main`), so a developer on a feature branch would publish previews under the
+`main` slug. In the `o.Development` block of `New()`, open the working tree with
+go-git and adopt the checked-out branch:
+
+```go
+if wtRepo, err := git.PlainOpenWithOptions(fs.repoDir, &git.PlainOpenOptions{DetectDotGit: true}); err == nil {
+    if head, err := wtRepo.Head(); err == nil && head.Name().IsBranch() {
+        o.Branch = head.Name().Short()
+    }
+}
+```
+
+Production is unchanged: outside dev mode the branch still comes from the flag.
+
+### A4. Tests — `internal/lume/erofs_test.go` (table-driven, per skill)
+
+- `TestBuildEROFS`: write a small tree into `t.TempDir()` (text + binary files, a
+  subdir), `buildEROFS`, reopen with `openEROFS`, assert each file round-trips via
+  `fs.ReadFile`, and that the hash is `hashLen` long.
+- `TestBuildEROFSDistinctContent`: different content yields different hashes.
+  (Volumes are **not** byte-reproducible across builds — see A2 — so determinism
+  cannot be asserted; each build legitimately gets its own permanent URL.)
+- `TestServeEROFS`: build a volume, serve it through `httptest` +
+  `http.FileServerFS`, and assert `GET /`, `/index.html`, and a nested path return
+  the right bytes — this is the actual "serve erofs over HTTP" path. Inner subtests
+  must **not** call `t.Parallel()` (the parent's `defer srv.Close()` would fire
+  first).
+- `TestOpenEROFSMissing`: opening a missing volume errors.
+
+---
+
+## Part B — New preview binary `cmd/futuresight`
+
+Reuses the existing `--future-sight-url` flag name and the FutureSight upload
+contract, but now in-repo, Tigris-backed, and serving content-addressed subdomains.
+(Name kept for continuity; `cmd/xesite-preview` is an alternative.)
+
+### B1. CLI skeleton (`cmd/futuresight/main.go`) — follows xe-go style
+
+`flagenv.Parse()` then `flag.Parse()`, `internal.Slog()`, kebab-case flags:
+
+- `--bind` (default `:3000`), `--internal-api-bind` (`:3001`, for `/healthz`)
+- `--tigris-bucket` (preview volume bucket)
+- `--base-domain` (e.g. `preview.xeiaso.net`) — used to strip the host label
+- `--cache-dir` (default `./var/volumes`) — local disk cache of fetched erofs
+  volumes; backed by a Kubernetes `emptyDir` mount in prod
+- `--upload-token` (bearer/HMAC shared secret guarding `/upload`)
+- Tigris creds from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env (already the
+  Tigris pattern in this repo) or explicit flags passed to `storage.WithAccessKeypair`.
+
+Construct one `*storage.Client` via `storage.New(ctx, storage.WithGlobalEndpoint(), ...)`.
+
+### B2. Object layout in Tigris
+
+- `volumes/<hash>.erofs` — immutable, content-addressed.
+- `branches/<branch-slug>` — tiny object whose body is the current `<hash>` for that
+  branch (the moving pointer). Updated on each upload.
+
+### B3. `POST /upload` (admin host / token-guarded)
+
+Mirror today's multipart contract (`lume.go`) plus metadata. Accept multipart
+form fields: `file` (the erofs volume), `branch`, `hash`.
+
+- Verify the `Authorization: Bearer <token>` header against `--upload-token`
+  (constant-time compare; empty token disables auth for local dev).
+- Stream `file` to a temp file in the cache dir while computing sha256 — the
+  **server is authoritative on the content hash**, so the client's `hash` field is
+  only advisory. `PutObject(volumes/<hash>.erofs)`
+  (`Content-Type: application/octet-stream`), then `os.Rename` the temp file into
+  the cache to prime it (the first serve skips the download round-trip).
+- Slugify `branch` → `PutObject(branches/<slug>)` with body `<hash>`.
+- Respond `200` with the hash so the client can log the resulting URL.
+
+**Upload host:** `api.preview.xeiaso.net`. `handleUpload` is host-agnostic
+(routed by path), so the existing `*.preview.xeiaso.net` wildcard ingress + cert
+already cover it — no extra ingress rule or cert. The endpoint is public and
+token-guarded; it caps the body via `http.MaxBytesReader` (`--max-upload-bytes`,
+default 512 MiB → `413` on overflow). Dev boxes set
+`FUTURE_SIGHT_URL=https://api.preview.xeiaso.net`; in-cluster xesite keeps using
+`http://futuresight.default.svc`.
+
+### B4. Host-based serving (`r.Host`)
+
+No host-routing exists today (only `internal/domain_redirect.go:31`), so add a
+small handler that:
+
+1. Strips `--base-domain` suffix from `r.Host` to get the leftmost label
+   (`<label>.preview.xeiaso.net` → `<label>`).
+2. If `label` is `hashLen` hex chars → treat as a content hash directly.
+   Else treat as a branch slug → `GetObject(branches/<label>)` to resolve `<hash>`.
+3. Serve the volume for `<hash>` via `http.FileServerFS(volumeFS)`.
+
+`resolveVolume(ctx, hash) (fs.FS, error)` — **disk-backed cache** in `--cache-dir`:
+
+- Cache path `filepath.Join(cacheDir, hash+".erofs")`. In-process
+  `map[string]*erofs.FS` (guarding the open handles) under a `sync.RWMutex`;
+  content-addressed volumes are immutable, so entries never expire.
+- On miss: if the cache file is absent, `GetObject(volumes/<hash>.erofs)` and stream
+  `.Body` to the cache file (download to a `<hash>.tmp` then atomic `os.Rename`, so a
+  crash mid-download can't leave a truncated volume). Then `os.Open` the cache file
+  (the `*os.File` is the `io.ReaderAt`) → `erofs.Open` → store in the map. Because
+  erofs reads lazily from the file, volumes are never loaded fully into memory.
+- Branch pointers are re-resolved per request (one small `GetObject(branches/<slug>)`),
+  so a new build is visible on the branch host immediately; the resolved `<hash>`
+  then hits the disk cache.
+
+### B5. Slugify helper + tests (`cmd/futuresight/slug.go`, `slug_test.go`)
+
+- `func slugifyBranch(s string) string`: lowercase, replace any run of non
+  `[a-z0-9]` with a single `-`, trim leading/trailing `-`, truncate to 63 chars
+  (DNS label limit). E.g. `feat/Foo_Bar` → `feat-foo-bar`.
+- Table-driven test covering: simple branch, slashes, uppercase, leading/trailing
+  junk, over-length truncation, unicode → ascii fallback. `t.Parallel()`, map or
+  slice of cases with `name`, `want`.
+
+### B6. Replace `futureSight()` in `internal/lume/lume.go`
+
+Change the POST body from `site.zip` to `site.erofs`, and write the `branch` and
+`hash` form fields (from `f.opt.Branch` — now working-tree-aware in dev mode, see
+A3a — and `f.VolumeHash()`) **before** the `file` part so a streaming reader sees
+them first. Send `Authorization: Bearer <token>` from a new
+`FutureSightToken` option, wired from a new xesite `--future-sight-token` flag
+(`cmd/xesite/main.go`). Keep the same `{FutureSightURL}/upload` endpoint and
+multipart shape so the call site (`go f.FutureSight(...)`) is unchanged; existing
+`futureSightPokes`/`futureSightErrors` metrics stay valid.
+
+---
+
+## Part C — Deployment
+
+Model on the existing `manifest/xesite/*` and `manifest/sponsor-panel/*` (nginx
+ingress + cert-manager + 1Password secrets).
+
+- New `manifest/futuresight/`: `deployment.yaml`, `service.yaml`,
+  `kustomization.yaml`, `1password.yaml` (Tigris keypair + upload token — reuse the
+  `xesite-anubis-tigris` OnePasswordItem pattern at `manifest/xesite/1password.yaml:18`).
+  Mount an `emptyDir` volume at the container's `--cache-dir` (mirror the existing
+  xesite `emptyDir` data mount in `manifest/xesite/deployment.yaml`). The cache is
+  pure scratch — losing it on pod restart just triggers a re-download from Tigris.
+- `ingress.yaml` with a **wildcard host** `*.preview.xeiaso.net`. Note: nginx
+  supports wildcard hosts, but cert-manager needs a **DNS-01** issuer for a
+  wildcard TLS cert (the existing `letsencrypt-prod` issuer uses HTTP-01, which
+  can't issue wildcards). This is the one real infra prerequisite — flag it for the
+  user; a DNS-01 ClusterIssuer (or a pre-provisioned wildcard cert) must exist.
+- Register the binary in the Docker build / Tekton pipeline alongside the other
+  `cmd/*` binaries (`docker/`, `.tekton/xe-site-pipeline.yaml`).
+- **Production xesite does not set `--future-sight-url`** — previews are a
+  development feature, so the in-cluster deployment leaves it empty and the
+  `if o.FutureSightURL != ""` guard skips the upload entirely (no token needed in
+  prod). Only dev boxes set `FUTURE_SIGHT_URL` (→ `https://api.preview.xeiaso.net`)
+  and `FUTURE_SIGHT_TOKEN` in their local `.env`.
+
+---
+
+## Verification (done)
+
+- `go build ./...`, `go vet`, `gofmt` clean. `go mod tidy` promoted `Xe/erofs` and
+  `tigrisdata/storage-go` to direct deps.
+- New table-driven tests pass: erofs build/open/**HTTP-serve** round-trips
+  (`internal/lume`), slugify, subdomain parsing, hash detection (`cmd/futuresight`).
+- **End-to-end (lume):** `go test ./internal/lume -run TestCanBuildSite` built the
+  real 782-file site into `site.erofs` (`hash=9fdda79a858ceadb`), opened it, and
+  served it — confirming the full Deno → erofs → `fs.FS` path.
+- **Preview binary (manual, needs a test Tigris bucket):** run `cmd/futuresight`,
+  `POST /upload` a built `site.erofs` with `branch=main`, then
+  `curl -H 'Host: <hash>.preview.localhost' …` and `-H 'Host: main.preview.localhost' …`
+  and confirm both serve the same content. The Tigris-backed `Store` is not unit
+  tested (no local creds); the serving/routing logic around it is.
+
+## Open prerequisite for the user
+
+Wildcard TLS for `*.preview.xeiaso.net` requires a DNS-01 cert-manager issuer (the
+current `letsencrypt-prod` is HTTP-01). Confirm whether such an issuer exists or
+should be added.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
+	github.com/Xe/erofs v0.4.0
 	github.com/a-h/templ v0.3.1020
 	github.com/aws/aws-sdk-go-v2 v1.41.8
 	github.com/aws/aws-sdk-go-v2/config v1.32.19
@@ -24,6 +25,7 @@ require (
 	github.com/orandin/slog-gorm v1.4.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
+	github.com/tigrisdata/storage-go v0.6.0
 	github.com/twitchtv/twirp v8.1.3+incompatible
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.81.0
@@ -151,6 +153,7 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/Songmu/gitconfig v0.2.1 h1:cZsqELfMtxWVI8ovq17gbvsR4qLfoYLAiXy5GwtJWb
 github.com/Songmu/gitconfig v0.2.1/go.mod h1:XM4O3SoXFnli9Ql2G7qXK2Fg7LJwf7Hs8GLFEOJlzmM=
 github.com/TecharoHQ/yeet v0.8.1 h1:wriCSlyIDIZKRPmrf6ZXZx7uiAdH+OvshNQkwW+hNw8=
 github.com/TecharoHQ/yeet v0.8.1/go.mod h1:PLlw/OTk9fCvobE5O0I7cIaxKuuB9A46yrEihTFHA9c=
+github.com/Xe/erofs v0.4.0 h1:8NrOSwUnui1UU+QZMhsPjSkcljA9IxVF88507x1vjHE=
+github.com/Xe/erofs v0.4.0/go.mod h1:GGxvJkCKU4yKfJ+Trap2xC8iN0HGuTUEsD5oz+olLJI=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e h1:HjVbSQHy+dnlS6C3XajZ69NYAb5jbGNfHanvm1+iYlo=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e/go.mod h1:3mnrkvGpurZ4ZrTDbYU84xhwXW2TjTKShSwjRi2ihfQ=
 github.com/a-h/templ v0.3.1020 h1:ypAT/L5ySWEnZ6Zft/5yfoWXYYkhFNvEFOeeqecg4tw=
@@ -485,6 +487,8 @@ github.com/orandin/slog-gorm v1.4.0 h1:FgA8hJufF9/jeNSYoEXmHPPBwET2gwlF3B85JdpsT
 github.com/orandin/slog-gorm v1.4.0/go.mod h1:MoZ51+b7xE9lwGNPYEhxcUtRNrYzjdcKvA8QXQQGEPA=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -575,6 +579,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tigrisdata/storage-go v0.6.0 h1:1Rxzxp/GAUqwFln8qMXYOQIa47IsT2aBNuxYc55o6D4=
+github.com/tigrisdata/storage-go v0.6.0/go.mod h1:l3u7N9LDIhv4lfpkEBJYzolWJ/SBb6WiBexgy/uq6iQ=
 github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
 github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=

--- a/internal/lume/erofs.go
+++ b/internal/lume/erofs.go
@@ -1,0 +1,117 @@
+package lume
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"time"
+
+	"github.com/Xe/erofs"
+)
+
+// hashLen is the number of hex characters kept from the sha256 of an erofs
+// volume. 16 hex chars (64 bits) is short enough to fit in a DNS label and
+// wide enough to avoid collisions across builds.
+const hashLen = 16
+
+// erofsBlockSize is the default EROFS block size (1 << 12). The volume file is
+// pre-sized to one block before Build so that finalizing a sub-block-sized image
+// (which reads the whole first block back to checksum the superblock) does not
+// hit io.EOF on a short *os.File read. EROFS images are block-aligned, so this
+// padding is part of a valid image.
+const erofsBlockSize = 4096
+
+// erofsFS wraps an *erofs.FS together with the file handle it reads from so
+// that closing the FS also releases the underlying file descriptor. erofs reads
+// lazily through the io.ReaderAt, so the handle must stay open for the lifetime
+// of the FS.
+type erofsFS struct {
+	*erofs.FS
+	f *os.File
+}
+
+func (e *erofsFS) Close() error {
+	return e.f.Close()
+}
+
+// buildEROFS builds an EROFS volume at destPath from the contents of srcDir and
+// returns the first hashLen hex characters of the sha256 of the resulting
+// volume. epoch is used as the filesystem epoch (inode mtimes). The returned
+// hash content-addresses this particular build; it is not byte-reproducible
+// across builds, so each build gets its own permanent address.
+func buildEROFS(srcDir, destPath string, epoch time.Time) (string, error) {
+	fout, err := os.Create(destPath)
+	if err != nil {
+		return "", fmt.Errorf("lume: can't create erofs volume %s: %w", destPath, err)
+	}
+
+	if err := fout.Truncate(erofsBlockSize); err != nil {
+		fout.Close()
+		return "", fmt.Errorf("lume: can't pre-size erofs volume: %w", err)
+	}
+
+	b := erofs.NewBuilder(fout,
+		erofs.WithEpoch(epoch),
+		erofs.WithCompression(erofs.CompressionAutoLZ4),
+	)
+
+	if err := b.AddFromFS(os.DirFS(srcDir)); err != nil {
+		fout.Close()
+		return "", fmt.Errorf("lume: can't add %s to erofs volume: %w", srcDir, err)
+	}
+
+	if err := b.Build(); err != nil {
+		fout.Close()
+		return "", fmt.Errorf("lume: can't finalize erofs volume: %w", err)
+	}
+
+	if err := fout.Close(); err != nil {
+		return "", fmt.Errorf("lume: can't close erofs volume: %w", err)
+	}
+
+	hash, err := hashFile(destPath)
+	if err != nil {
+		return "", err
+	}
+
+	return hash, nil
+}
+
+// hashFile streams the file at path through sha256 and returns the first hashLen
+// hex characters of the digest.
+func hashFile(path string) (string, error) {
+	fin, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("lume: can't open %s for hashing: %w", path, err)
+	}
+	defer fin.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, fin); err != nil {
+		return "", fmt.Errorf("lume: can't hash %s: %w", path, err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil))[:hashLen], nil
+}
+
+// openEROFS opens the EROFS volume at path as a read-only fs.FS. The returned
+// *erofsFS owns the file handle and must be closed to release it.
+func openEROFS(path string) (*erofsFS, error) {
+	fin, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("lume: can't open erofs volume %s: %w", path, err)
+	}
+
+	efs, err := erofs.Open(fin)
+	if err != nil {
+		fin.Close()
+		return nil, fmt.Errorf("lume: can't read erofs volume %s: %w", path, err)
+	}
+
+	return &erofsFS{FS: efs, f: fin}, nil
+}
+
+var _ fs.FS = (*erofsFS)(nil)

--- a/internal/lume/erofs_test.go
+++ b/internal/lume/erofs_test.go
@@ -1,0 +1,180 @@
+package lume
+
+import (
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTree writes the given relative path -> contents map into dir, creating
+// parent directories as needed.
+func writeTree(t *testing.T, dir string, files map[string][]byte) {
+	t.Helper()
+
+	for name, data := range files {
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("can't create dir for %s: %v", name, err)
+		}
+		if err := os.WriteFile(full, data, 0o644); err != nil {
+			t.Fatalf("can't write %s: %v", name, err)
+		}
+	}
+}
+
+func TestBuildEROFS(t *testing.T) {
+	t.Parallel()
+
+	epoch := time.Unix(1700000000, 0)
+
+	for _, tt := range []struct {
+		name  string
+		files map[string][]byte
+	}{
+		{
+			name: "single text file",
+			files: map[string][]byte{
+				"index.html": []byte("<h1>hello</h1>"),
+			},
+		},
+		{
+			name: "nested dirs with mixed content",
+			files: map[string][]byte{
+				"index.html":         []byte("<h1>hello</h1>"),
+				"blog/post/one.html": []byte("post one"),
+				"static/blob.bin":    {0x00, 0x01, 0x02, 0xff, 0xfe},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srcDir := t.TempDir()
+			writeTree(t, srcDir, tt.files)
+
+			destPath := filepath.Join(t.TempDir(), "site.erofs")
+			hash, err := buildEROFS(srcDir, destPath, epoch)
+			if err != nil {
+				t.Fatalf("buildEROFS: %v", err)
+			}
+
+			if len(hash) != hashLen {
+				t.Errorf("got hash length %d, want %d (%q)", len(hash), hashLen, hash)
+			}
+
+			efs, err := openEROFS(destPath)
+			if err != nil {
+				t.Fatalf("openEROFS: %v", err)
+			}
+			defer efs.Close()
+
+			for name, want := range tt.files {
+				got, err := fs.ReadFile(efs, name)
+				if err != nil {
+					t.Errorf("ReadFile(%q): %v", name, err)
+					continue
+				}
+				if string(got) != string(want) {
+					t.Errorf("ReadFile(%q) = %q, want %q", name, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildEROFSDistinctContent(t *testing.T) {
+	t.Parallel()
+
+	epoch := time.Unix(1700000000, 0)
+
+	build := func(files map[string][]byte) string {
+		t.Helper()
+		srcDir := t.TempDir()
+		writeTree(t, srcDir, files)
+		destPath := filepath.Join(t.TempDir(), "site.erofs")
+		hash, err := buildEROFS(srcDir, destPath, epoch)
+		if err != nil {
+			t.Fatalf("buildEROFS: %v", err)
+		}
+		return hash
+	}
+
+	// Different content must yield different content-addresses. (Volumes are not
+	// byte-reproducible across builds — the EROFS superblock embeds the build
+	// time and the builder lays out directory entries in map order — so each
+	// build legitimately gets its own permanent URL.)
+	a := build(map[string][]byte{"index.html": []byte("version a")})
+	b := build(map[string][]byte{"index.html": []byte("version b")})
+
+	if a == b {
+		t.Errorf("different content produced the same hash: %q", a)
+	}
+}
+
+func TestServeEROFS(t *testing.T) {
+	t.Parallel()
+
+	srcDir := t.TempDir()
+	writeTree(t, srcDir, map[string][]byte{
+		"index.html":         []byte("<h1>home</h1>"),
+		"blog/post/one.html": []byte("post one"),
+	})
+
+	destPath := filepath.Join(t.TempDir(), "site.erofs")
+	if _, err := buildEROFS(srcDir, destPath, time.Unix(1700000000, 0)); err != nil {
+		t.Fatalf("buildEROFS: %v", err)
+	}
+
+	efs, err := openEROFS(destPath)
+	if err != nil {
+		t.Fatalf("openEROFS: %v", err)
+	}
+	defer efs.Close()
+
+	srv := httptest.NewServer(http.FileServerFS(efs))
+	defer srv.Close()
+
+	for _, tt := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "root serves index", path: "/", want: "<h1>home</h1>"},
+		{name: "explicit index", path: "/index.html", want: "<h1>home</h1>"},
+		{name: "nested file", path: "/blog/post/one.html", want: "post one"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + tt.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tt.path, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("GET %s: status %d, want 200", tt.path, resp.StatusCode)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if string(body) != tt.want {
+				t.Errorf("GET %s = %q, want %q", tt.path, body, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenEROFSMissing(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.erofs")
+	if _, err := openEROFS(missing); err == nil {
+		t.Fatal("openEROFS on missing file: want error, got nil")
+	}
+}

--- a/internal/lume/lume.go
+++ b/internal/lume/lume.go
@@ -84,6 +84,7 @@ type FS struct {
 	fs   fs.FS
 	lock sync.RWMutex
 
+	volumeHash    string
 	lastBuildTime time.Time
 }
 
@@ -119,6 +120,20 @@ func (f *FS) BuildTime() time.Time {
 	return f.lastBuildTime
 }
 
+// VolumeHash returns the truncated sha256 of the most recently built erofs
+// volume. It content-addresses the current build for the preview site.
+func (f *FS) VolumeHash() string {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	return f.volumeHash
+}
+
+// Branch returns the git branch this site was built from.
+func (f *FS) Branch() string {
+	return f.opt.Branch
+}
+
 func (f *FS) Open(name string) (fs.File, error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
@@ -134,15 +149,16 @@ func (f *FS) Open(name string) (fs.File, error) {
 }
 
 type Options struct {
-	Development    bool
-	Branch         string
-	Repo           string
-	StaticSiteDir  string
-	URL            string
-	PatreonClient  *patreon.Client
-	DataDir        string
-	MiURL          string
-	FutureSightURL string
+	Development      bool
+	Branch           string
+	Repo             string
+	StaticSiteDir    string
+	URL              string
+	PatreonClient    *patreon.Client
+	DataDir          string
+	MiURL            string
+	FutureSightURL   string
+	FutureSightToken string
 }
 
 func New(ctx context.Context, o *Options) (*FS, error) {
@@ -181,6 +197,16 @@ func New(ctx context.Context, o *Options) (*FS, error) {
 		fs.repoDir, err = os.Getwd()
 		if err != nil {
 			return nil, err
+		}
+
+		// In dev mode the build reads the working tree rather than the clone, so
+		// discover the branch the developer actually has checked out instead of
+		// trusting the --git-branch flag.
+		if wtRepo, err := git.PlainOpenWithOptions(fs.repoDir, &git.PlainOpenOptions{DetectDotGit: true}); err == nil {
+			if head, err := wtRepo.Head(); err == nil && head.Name().IsBranch() {
+				o.Branch = head.Name().Short()
+				slog.Debug("using working tree branch", "branch", o.Branch)
+			}
 		}
 	} else {
 		wt, err := repo.Worktree()
@@ -365,13 +391,30 @@ func (f *FS) build(ctx context.Context, siteCommit string) error {
 		return fmt.Errorf("lume: can't compress site folder: %w", err)
 	}
 
+	volumeLoc := filepath.Join(f.opt.DataDir, "site.erofs")
+
+	hash, err := buildEROFS(destDir, volumeLoc, begin)
+	if err != nil {
+		return err
+	}
+
+	// Open the new volume before closing the old FS so a failed open keeps the
+	// previous build serving.
+	efs, err := openEROFS(volumeLoc)
+	if err != nil {
+		return err
+	}
+
 	if cl, ok := f.fs.(io.Closer); f.fs != nil && ok {
 		if err := cl.Close(); err != nil {
 			slog.Error("failed to close old fs", "err", err)
 		}
 	}
 
-	f.fs = os.DirFS(destDir)
+	f.fs = efs
+	f.volumeHash = hash
+
+	slog.Info("built erofs volume", "loc", volumeLoc, "hash", hash, "time", dur.String())
 
 	return nil
 }
@@ -649,18 +692,29 @@ func (f *FS) FutureSight(ctx context.Context) {
 }
 
 func (f *FS) futureSight(ctx context.Context) error {
-	zipLoc := filepath.Join(f.opt.DataDir, "site.zip")
+	volumeLoc := filepath.Join(f.opt.DataDir, "site.erofs")
 
-	fin, err := os.Open(zipLoc)
+	fin, err := os.Open(volumeLoc)
 	if err != nil {
-		return fmt.Errorf("lume: can't open site zip for future sight: %w", err)
+		return fmt.Errorf("lume: can't open site volume for future sight: %w", err)
 	}
 	defer fin.Close()
+
+	hash := f.VolumeHash()
 
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
 
-	part, err := writer.CreateFormFile("file", filepath.Base(zipLoc))
+	// Write metadata fields before the file so a streaming reader sees them first.
+	if err := writer.WriteField("branch", f.opt.Branch); err != nil {
+		return fmt.Errorf("lume: can't write branch field: %w", err)
+	}
+
+	if err := writer.WriteField("hash", hash); err != nil {
+		return fmt.Errorf("lume: can't write hash field: %w", err)
+	}
+
+	part, err := writer.CreateFormFile("file", filepath.Base(volumeLoc))
 	if err != nil {
 		return fmt.Errorf("lume: can't create form file: %w", err)
 	}
@@ -679,17 +733,21 @@ func (f *FS) futureSight(ctx context.Context) error {
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if f.opt.FutureSightToken != "" {
+		req.Header.Set("Authorization", "Bearer "+f.opt.FutureSightToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("lume: can't post to future sight: %w", err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return web.NewError(http.StatusOK, resp)
 	}
 
-	slog.Info("deployed to preview site")
+	slog.Info("deployed to preview site", "hash", hash, "branch", f.opt.Branch)
 
 	return nil
 }

--- a/manifest/futuresight/1password.yaml
+++ b/manifest/futuresight/1password.yaml
@@ -1,0 +1,9 @@
+# Provides the `futuresight` secret with UPLOAD_TOKEN, which must match the
+# value passed to xesite as --future-sight-token. Replace itemPath with the real
+# 1Password item before applying.
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: futuresight
+spec:
+  itemPath: "vaults/lc5zo4zjz3if3mkeuhufjmgmui/items/cml67o7ywcwldh75r3xffgfl5q"

--- a/manifest/futuresight/deployment.yaml
+++ b/manifest/futuresight/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: futuresight
+  labels:
+    app.kubernetes.io/name: futuresight
+    app.kubernetes.io/component: web
+  annotations:
+    keel.sh/policy: all
+    keel.sh/trigger: poll
+    keel.sh/pollSchedule: "@every 5m"
+    operator.1password.io/auto-restart: "true"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: futuresight
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: futuresight
+        app.kubernetes.io/component: web
+    spec:
+      volumes:
+        # Scratch cache of downloaded erofs volumes. Losing it on restart just
+        # triggers a re-download from Tigris.
+        - name: cache
+          emptyDir: {}
+      containers:
+        - name: web
+          image: ghcr.io/xe/site/futuresight:latest
+          imagePullPolicy: Always
+          env:
+            - name: "BIND"
+              value: ":3000"
+            - name: "INTERNAL_API_BIND"
+              value: ":3001"
+            - name: "BASE_DOMAIN"
+              value: "preview.xeiaso.net"
+            - name: "CACHE_DIR"
+              value: "/xe/cache"
+            - name: "TIGRIS_BUCKET"
+              value: "xesite-future-sight"
+          envFrom:
+            # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for Tigris (reused from
+            # the xesite Tigris credentials).
+            - secretRef:
+                name: xesite-anubis-tigris
+            # UPLOAD_TOKEN, shared with xesite's --future-sight-token.
+            - secretRef:
+                name: futuresight
+          ports:
+            - containerPort: 3000
+              name: http
+          volumeMounts:
+            - mountPath: "/xe/cache"
+              name: cache
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3001
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/manifest/futuresight/ingress.yaml
+++ b/manifest/futuresight/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: futuresight
+  annotations:
+    # NOTE: a wildcard certificate for *.preview.xeiaso.net requires a DNS-01
+    # solver. The default letsencrypt-prod issuer used elsewhere in this repo is
+    # HTTP-01, which cannot issue wildcards. Point this at a DNS-01 ClusterIssuer
+    # (or pre-provision the preview-xeiaso-net-tls secret) before applying.
+    #
+    # The wildcard also covers the upload host api.preview.xeiaso.net, which
+    # handleUpload (host-agnostic, token-guarded) serves. Dev boxes POST builds
+    # there; in-cluster xesite uses http://futuresight.default.svc instead.
+    cert-manager.io/cluster-issuer: "letsencrypt-dns"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "*.preview.xeiaso.net"
+      secretName: preview-xeiaso-net-tls
+  rules:
+    - host: "*.preview.xeiaso.net"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: futuresight
+                port:
+                  number: 80

--- a/manifest/futuresight/kustomization.yaml
+++ b/manifest/futuresight/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - 1password.yaml
+  - deployment.yaml
+  - ingress.yaml
+  - service.yaml

--- a/manifest/futuresight/service.yaml
+++ b/manifest/futuresight/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: futuresight
+  labels:
+    app.kubernetes.io/name: futuresight
+spec:
+  selector:
+    app.kubernetes.io/name: futuresight
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+      name: http
+    - port: 8080
+      targetPort: 3001
+      protocol: TCP
+      name: internalapi

--- a/manifest/kustomization.yaml
+++ b/manifest/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - futuresight
   - patreon-saasproxy
   - sponsor-panel
   - xesite


### PR DESCRIPTION
## Summary

Introduces futuresight, a new standalone service for storing and serving xesite builds as immutable EROFS volumes in Tigris. Each build is content-addressed by its truncated sha256 hash and accessible on both permanent subdomains (keyed by hash) and moving subdomains (keyed by git branch slug).

**Key features:**
- EROFS volumes replace zip for serving (faster, content-addressed)
- Token-guarded upload endpoint at `https://api.preview.xeiaso.net/upload`
- Wildcard preview subdomains: `<hash>.preview.xeiaso.net` and `<branch-slug>.preview.xeiaso.net`
- Disk-backed local cache (emptyDir in production) to avoid full-volume buffering
- Dev-mode branch discovery using git working-tree checkout
- Upload size limits (default 512 MiB) + constant-time token comparison
- Integration tests against real Tigris bucket (skipped without credentials)

## Verification

- `go build ./...` and `go test ./...` pass
- 782-file end-to-end build → erofs → fs.FS → http.FileServerFS ✓
- Real Tigris integration tested: PutVolume, SetBranch, ResolveBranch, Volume (with forced download + cache prime)
- Uploads validated with multipart form parsing, bearer token auth, and size capping
- Branch slugification covers slashes, unicode, truncation, case normalization

## Development Setup

Dev boxes set in `.env`:
```
FUTURE_SIGHT_URL=https://api.preview.xeiaso.net
FUTURE_SIGHT_TOKEN=<from 'go run ./cmd/futuresight -generate-token'>
```

Production xesite intentionally leaves these empty (previews are dev-only).

## Deployments

- futuresight Kubernetes manifests added (deployment, service, wildcard ingress)
- Requires DNS-01 cert-manager issuer for wildcard TLS cert
- Xesite Tekton task added alongside the new binary
- Docker bake target added for multi-arch image builds

See `docs/superpowers/plans/2026-06-01-erofs-serving.md` for full design and implementation notes.